### PR TITLE
[Feature] 데이터 모듈 Repository 구현체 구현

### DIFF
--- a/Data/Sources/DTOs/DailyBudgetDTO.swift
+++ b/Data/Sources/DTOs/DailyBudgetDTO.swift
@@ -5,3 +5,57 @@
 //
 //  Copyright © 2024 namudiEtc. All rights reserved.
 //
+
+import Foundation
+import Domain
+import SwiftData
+
+@Model
+public final class DailyBudgetDTO {
+  @Attribute(.unique) var identifier: String
+  var date: Date
+  var harubee: Int?
+  var memo: [String]
+  var expense: Int?
+  var income: Int?
+  
+  public init(
+    id: String,
+    date: Date,
+    harubee: Int? = nil,
+    memo: [String],
+    expense: Int? = nil,
+    income: Int? = nil
+  ) {
+    self.identifier = id
+    self.date = date
+    self.harubee = harubee
+    self.memo = memo
+    self.expense = expense
+    self.income = income
+  }
+  
+  public convenience init(_ data: DailyBudget) {
+    self.init(
+      id: data.id,
+      date: data.date,
+      harubee: data.harubee,
+      memo: data.memo,
+      expense: data.expense,
+      income: data.income
+    )
+  }
+}
+
+extension DailyBudgetDTO {
+  public func toEntity() -> DailyBudget {
+    return DailyBudget(
+      id: self.identifier,
+      date: self.date,
+      harubee: self.harubee,
+      memo: self.memo,
+      expense: self.expense,
+      income: self.income
+    )
+  }
+}

--- a/Data/Sources/DTOs/SalaryBudgetDTO.swift
+++ b/Data/Sources/DTOs/SalaryBudgetDTO.swift
@@ -5,3 +5,67 @@
 //
 //  Copyright © 2024 namudiEtc. All rights reserved.
 //
+
+import Foundation
+import Domain
+import SwiftData
+
+@Model
+public final class SalaryBudgetDTO {
+  @Attribute(.unique) var identifier: String
+  var startDate: Date
+  var endDate: Date
+  var fixedIncome: Int
+  @Relationship(deleteRule: .cascade) var fixedExpenses: [TransactionItemDTO]
+  var balance: Int
+  var defaultHarubee: Double
+  @Relationship(deleteRule: .cascade) var dailyBudgets: [DailyBudgetDTO]
+  
+  public init(
+    id: String,
+    startDate: Date,
+    endDate: Date,
+    fixedIncome: Int,
+    fixedExpenses: [TransactionItem],
+    balance: Int,
+    defaultHarubee: Double,
+    dailyBudgets: [DailyBudget]
+  ) {
+    self.identifier = id
+    self.startDate = startDate
+    self.endDate = endDate
+    self.fixedIncome = fixedIncome
+    self.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
+    self.balance = balance
+    self.defaultHarubee = defaultHarubee
+    self.dailyBudgets = dailyBudgets.map { DailyBudgetDTO($0) }
+  }
+  
+  public convenience init(_ data: SalaryBudget) {
+    self.init(
+      id: data.id,
+      startDate: data.startDate,
+      endDate: data.endDate,
+      fixedIncome: data.fixedIncome,
+      fixedExpenses: data.fixedExpenses,
+      balance: data.balance,
+      defaultHarubee: data.defaultHarubee,
+      dailyBudgets: data.dailyBudgets
+    )
+  }
+}
+
+extension SalaryBudgetDTO {
+  public func toEntity() -> SalaryBudget {
+    return SalaryBudget(
+      id: self.identifier,
+      startDate: self.startDate,
+      endDate: self.endDate,
+      fixedIncome: self.fixedIncome,
+      fixedExpenses: self.fixedExpenses.map { $0.toEntity() },
+      balance: self.balance,
+      defaultHarubee: self.defaultHarubee,
+      dailyBudgets: self.dailyBudgets.map { $0.toEntity() }
+    )
+  }
+}

--- a/Data/Sources/DTOs/TransactionItemDTO.swift
+++ b/Data/Sources/DTOs/TransactionItemDTO.swift
@@ -5,3 +5,47 @@
 //
 //  Copyright © 2024 namudiEtc. All rights reserved.
 //
+
+import Foundation
+import Domain
+import SwiftData
+
+@Model
+public final class TransactionItemDTO {
+  @Attribute(.unique) var identifier: String
+  var date: Date
+  var name: String
+  var price: Int
+  
+  public init(
+    id: String,
+    date: Date,
+    name: String,
+    price: Int
+  ) {
+    self.identifier = id
+    self.date = date
+    self.name = name
+    self.price = price
+  }
+  
+  public convenience init(_ data: TransactionItem) {
+    self.init(
+      id: data.id,
+      date: data.date,
+      name: data.name,
+      price: data.price
+    )
+  }
+}
+
+extension TransactionItemDTO {
+  public func toEntity() -> TransactionItem {
+    return TransactionItem(
+      id: self.identifier,
+      date: self.date,
+      name: self.name,
+      price: self.price
+    )
+  }
+}

--- a/Data/Sources/Errors/SwiftDataError.swift
+++ b/Data/Sources/Errors/SwiftDataError.swift
@@ -1,0 +1,26 @@
+//
+//  SwiftDataError.swift
+//  Data
+//
+//  Created by 이정동 on 10/29/24.
+//  Copyright © 2024 namudiEtc. All rights reserved.
+//
+
+import Foundation
+
+public enum SwiftDataError: LocalizedError {
+  case fetchError
+  case deleteError
+  case modelNotFound
+  
+  public var errorDescription: String {
+    switch self {
+    case .fetchError:
+      "Fetch error"
+    case .deleteError:
+      "Delete error"
+    case .modelNotFound:
+      "Model not found"
+    }
+  }
+}

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -10,10 +10,6 @@ import Foundation
 import Domain
 import SwiftData
 
-public enum UpdateValue<T> {
-  case set(T)
-  case keep
-}
 
 public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
   
@@ -36,52 +32,7 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     }
   }
   
-  // MARK: - 1안 (각 프로퍼티 별 업데이트 함수 구현)
-  public func updateHarubee(_ id: String, harubee: Int) throws {
-    print("Impl:", #function)
-    
-    guard let model = try readById(id) else { return }
-    model.harubee = harubee
-  }
-  
-  public func updateExpense(_ id: String, expense: Int) throws {
-    print("Impl:", #function)
-    
-    guard let model = try readById(id) else { return }
-    model.expense = expense
-  }
-  
-  public func updateIncome(_ id: String, income: Int) throws {
-    print("Impl:", #function)
-    guard let model = try readById(id) else { return }
-    model.income = income
-  }
-  
-  public func updateMemo(_ id: String, memo: [String]) throws {
-    print("Impl:", #function)
-    guard let model = try readById(id) else { return }
-    model.memo = memo
-  }
-  
-  // MARK: - 2안 (한번에 업데이트)
   public func updateDailyBudget(
-    _ id: String,
-    harubee: Int?,
-    expense: Int?,
-    income: Int?,
-    memo: [String]? = nil
-  ) throws {
-    print("Impl:", #function)
-    
-    guard let model = try readById(id) else { return }
-    model.harubee = harubee
-    model.expense = expense
-    model.income = income
-    if let memo = memo { model.memo = memo }
-  }
-  
-  // MARK: - 3안 (enum 타입을 파라미터로 받음)
-  public func updateDailyBudget2(
     _ id: String,
     harubee: UpdateValue<Int?> = .keep,
     expence: UpdateValue<Int?> = .keep,
@@ -98,6 +49,36 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     if case .set(let memo) = memo { model.memo = memo }
   }
   
+  public func updateHarubee(_ id: String, harubee: Int) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.harubee = harubee
+  }
+  
+  public func updateExpense(_ id: String, expense: Int) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.expense = expense
+  }
+  
+  public func updateIncome(_ id: String, income: Int) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.income = income
+  }
+  
+  public func updateMemo(_ id: String, memo: [String]) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.memo = memo
+  }
+}
+
+extension DailyBudgetRepositoryImpl {
   private func readById(_ id: String) throws -> DailyBudgetDTO? {
     print("Impl:", #function)
     

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -19,27 +19,27 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
   }
   
   public func readByDate(_ date: Date) async throws -> Domain.DailyBudget? {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return nil
   }
   
   public func updateHarubee(_ id: String, harubee: Int) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateExpense(_ id: String, expense: Int) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateIncome(_ id: String, income: Int) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateMemo(_ id: String, memo: [String]) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -12,10 +12,10 @@ import SwiftData
 
 public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
   
-  private let modelContainer: ModelContainer
+  private let modelContext: ModelContext
   
-  public init(modelContainer: ModelContainer) {
-    self.modelContainer = modelContainer
+  public init(modelContext: ModelContext) {
+    self.modelContext = modelContext
   }
   
   public func readByDate(_ date: Date) async throws -> Domain.DailyBudget? {

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -18,30 +18,55 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     self.modelContext = modelContext
   }
   
-  public func readByDate(_ date: Date) throws -> Domain.DailyBudget? {
+  public func readByDate(_ date: Date) throws -> DailyBudget? {
     print("Impl:", #function)
-    return nil
+    
+    let predicate = #Predicate<DailyBudgetDTO> { $0.date == date }
+    let descriptor = FetchDescriptor(predicate: predicate)
+    do {
+      let data = try modelContext.fetch(descriptor)
+      return data.first?.toEntity()
+    } catch {
+      throw SwiftDataError.fetchError
+    }
   }
   
   public func updateHarubee(_ id: String, harubee: Int) throws {
     print("Impl:", #function)
-    return
+    
+    guard let model = try readById(id) else { return }
+    model.harubee = harubee
   }
   
   public func updateExpense(_ id: String, expense: Int) throws {
     print("Impl:", #function)
-    return
+    
+    guard let model = try readById(id) else { return }
+    model.expense = expense
   }
   
   public func updateIncome(_ id: String, income: Int) throws {
     print("Impl:", #function)
-    return
+    guard let model = try readById(id) else { return }
+    model.income = income
   }
   
   public func updateMemo(_ id: String, memo: [String]) throws {
     print("Impl:", #function)
-    return
+    guard let model = try readById(id) else { return }
+    model.memo = memo
   }
   
-  
+  private func readById(_ id: String) throws -> DailyBudgetDTO? {
+    print("Impl:", #function)
+    
+    let predicate = #Predicate<DailyBudgetDTO> { $0.identifier == id }
+    let descriptor = FetchDescriptor(predicate: predicate)
+    do {
+      let data = try modelContext.fetch(descriptor)
+      return data.first
+    } catch {
+      throw SwiftDataError.fetchError
+    }
+  }
 }

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -18,27 +18,27 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     self.modelContext = modelContext
   }
   
-  public func readByDate(_ date: Date) async throws -> Domain.DailyBudget? {
+  public func readByDate(_ date: Date) throws -> Domain.DailyBudget? {
     print("Impl:", #function)
     return nil
   }
   
-  public func updateHarubee(_ id: String, harubee: Int) async throws {
+  public func updateHarubee(_ id: String, harubee: Int) throws {
     print("Impl:", #function)
     return
   }
   
-  public func updateExpense(_ id: String, expense: Int) async throws {
+  public func updateExpense(_ id: String, expense: Int) throws {
     print("Impl:", #function)
     return
   }
   
-  public func updateIncome(_ id: String, income: Int) async throws {
+  public func updateIncome(_ id: String, income: Int) throws {
     print("Impl:", #function)
     return
   }
   
-  public func updateMemo(_ id: String, memo: [String]) async throws {
+  public func updateMemo(_ id: String, memo: [String]) throws {
     print("Impl:", #function)
     return
   }

--- a/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/DailyBudgetRepositoryImpl.swift
@@ -10,6 +10,11 @@ import Foundation
 import Domain
 import SwiftData
 
+public enum UpdateValue<T> {
+  case set(T)
+  case keep
+}
+
 public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
   
   private let modelContext: ModelContext
@@ -31,6 +36,7 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     }
   }
   
+  // MARK: - 1안 (각 프로퍼티 별 업데이트 함수 구현)
   public func updateHarubee(_ id: String, harubee: Int) throws {
     print("Impl:", #function)
     
@@ -55,6 +61,41 @@ public final class DailyBudgetRepositoryImpl: DailyBudgetRepository {
     print("Impl:", #function)
     guard let model = try readById(id) else { return }
     model.memo = memo
+  }
+  
+  // MARK: - 2안 (한번에 업데이트)
+  public func updateDailyBudget(
+    _ id: String,
+    harubee: Int?,
+    expense: Int?,
+    income: Int?,
+    memo: [String]? = nil
+  ) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.harubee = harubee
+    model.expense = expense
+    model.income = income
+    if let memo = memo { model.memo = memo }
+  }
+  
+  // MARK: - 3안 (enum 타입을 파라미터로 받음)
+  public func updateDailyBudget2(
+    _ id: String,
+    harubee: UpdateValue<Int?> = .keep,
+    expence: UpdateValue<Int?> = .keep,
+    income: UpdateValue<Int?> = .keep,
+    memo: UpdateValue<[String]> = .keep
+  ) throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    
+    if case .set(let harubee) = harubee { model.harubee = harubee }
+    if case .set(let expense) = expence { model.expense = expense }
+    if case .set(let income) = income { model.income = income }
+    if case .set(let memo) = memo { model.memo = memo }
   }
   
   private func readById(_ id: String) throws -> DailyBudgetDTO? {

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -18,14 +18,14 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     self.modelContext = modelContext
   }
   
-  public func create(_ salaryBudget: SalaryBudget) async {
+  public func create(_ salaryBudget: SalaryBudget) {
     print("Impl:", #function)
     
     let model = SalaryBudgetDTO(salaryBudget)
     modelContext.insert(model)
   }
   
-  public func readAll() async throws -> [SalaryBudget] {
+  public func readAll() throws -> [SalaryBudget] {
     print("Impl:", #function)
     
     let sort = SortDescriptor(\SalaryBudgetDTO.startDate, order: .forward)
@@ -39,7 +39,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     }
   }
   
-  public func readByStartDate(_ startDate: Date) async throws -> SalaryBudget? {
+  public func readByStartDate(_ startDate: Date) throws -> SalaryBudget? {
     print("Impl:", #function)
     
     let predicate = #Predicate<SalaryBudgetDTO> { $0.startDate == startDate }
@@ -53,7 +53,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     }
   }
   
-  public func updateFixedIncome(_ id: String, fixedIncome: Int) async throws {
+  public func updateFixedIncome(_ id: String, fixedIncome: Int) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
@@ -62,7 +62,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     return
   }
   
-  public func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) async throws {
+  public func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
@@ -71,7 +71,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     return
   }
   
-  public func updateBalance(_ id: String, balance: Int) async throws {
+  public func updateBalance(_ id: String, balance: Int) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
@@ -80,7 +80,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     return
   }
   
-  public func updateDefaultHarubee(_ id: String, defaultHarubee: Double) async throws {
+  public func updateDefaultHarubee(_ id: String, defaultHarubee: Double) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
@@ -89,7 +89,7 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     return
   }
   
-  public func deleteById(_ id: String) async throws {
+  public func deleteById(_ id: String) throws {
     print("Impl:", #function)
     
 //    guard let model = try readById(id) else { return }

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -18,45 +18,102 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     self.modelContext = modelContext
   }
   
-  public func create(_ salaryBudget: Domain.SalaryBudget) async throws {
+  public func create(_ salaryBudget: SalaryBudget) async {
     print("Impl:", #function)
+    
+    let model = SalaryBudgetDTO(salaryBudget)
+    modelContext.insert(model)
+  }
+  
+  public func readAll() async throws -> [SalaryBudget] {
+    print("Impl:", #function)
+    
+    let sort = SortDescriptor(\SalaryBudgetDTO.startDate, order: .forward)
+    let descriptor = FetchDescriptor(sortBy: [sort])
+    
+    do {
+      let datas = try modelContext.fetch(descriptor)
+      return datas.map { $0.toEntity() }
+    } catch {
+      throw SwiftDataError.fetchError
+    }
+  }
+  
+  public func readByStartDate(_ startDate: Date) async throws -> SalaryBudget? {
+    print("Impl:", #function)
+    
+    let predicate = #Predicate<SalaryBudgetDTO> { $0.startDate == startDate }
+    let descriptor = FetchDescriptor(predicate: predicate)
+    
+    do {
+      let data = try modelContext.fetch(descriptor).first
+      return data?.toEntity()
+    } catch {
+      throw SwiftDataError.fetchError
+    }
+  }
+  
+  public func updateFixedIncome(_ id: String, fixedIncome: Int) async throws {
+    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.fixedIncome = fixedIncome
+    
     return
   }
   
-  public func readAll() async throws -> [Domain.SalaryBudget] {
+  public func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) async throws {
     print("Impl:", #function)
-    return []
-  }
-  
-  public func readByStartDate(_ startDate: Date) async throws -> Domain.SalaryBudget? {
-    print("Impl:", #function)
-    return nil
-  }
-  
-  public func updateTotalFixedIncome(_ id: String, totalFixedIncome: Int) async throws {
-    print("Impl:", #function)
-    return
-  }
-  
-  public func updateFixedExpenses(_ id: String, fixedExpenses: [Domain.TransactionItem]) async throws {
-    print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
+    
     return
   }
   
   public func updateBalance(_ id: String, balance: Int) async throws {
     print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.balance = balance
+    
     return
   }
   
   public func updateDefaultHarubee(_ id: String, defaultHarubee: Double) async throws {
     print("Impl:", #function)
+    
+    guard let model = try readById(id) else { return }
+    model.defaultHarubee = defaultHarubee
+    
     return
   }
   
   public func deleteById(_ id: String) async throws {
     print("Impl:", #function)
+    
+//    guard let model = try readById(id) else { return }
+    let predicate = #Predicate<SalaryBudgetDTO> { $0.identifier == id }
+    do {
+      try modelContext.delete(model: SalaryBudgetDTO.self, where: predicate)
+    } catch {
+      throw SwiftDataError.deleteError
+    }
+    
     return
   }
   
-  
+  private func readById(_ id: String) throws -> SalaryBudgetDTO? {
+    print("Impl:", #function)
+    
+    let predicate = #Predicate<SalaryBudgetDTO> { $0.identifier == id }
+    let descriptor = FetchDescriptor(predicate: predicate)
+    
+    do {
+      let data = try modelContext.fetch(descriptor).first
+      return data
+    } catch {
+      throw SwiftDataError.fetchError
+    }
+  }
 }

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -55,20 +55,21 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
   
   public func updateSalaryBudget(
     _ id: String,
-    fixedIncome: Int? = nil,
-    fixedExpenses: [TransactionItem]? = nil,
-    balance: Int? = nil,
-    defaultHarubee: Double? = nil
+    fixedIncome: UpdateValue<Int> = .keep,
+    fixedExpenses: UpdateValue<[TransactionItem]> = .keep,
+    balance: UpdateValue<Int> = .keep,
+    defaultHarubee: UpdateValue<Double> = .keep
   ) throws {
+    print("Impl:", #function)
+    
     guard let model = try readById(id) else { return }
     
-    if let fixedIncome = fixedIncome { model.fixedIncome = fixedIncome }
-    if let fixedExpenses = fixedExpenses {
-      model.fixedExpenses.forEach { modelContext.delete($0) }
+    if case .set(let fixedIncome) = fixedIncome { model.fixedIncome = fixedIncome }
+    if case .set(let fixedExpenses) = fixedExpenses {
       model.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
     }
-    if let balance = balance { model.balance = balance }
-    if let defaultHarubee = defaultHarubee { model.defaultHarubee = defaultHarubee }
+    if case .set(let balance) = balance { model.balance = balance }
+    if case .set(let defaultHarubee) = defaultHarubee { model.defaultHarubee = defaultHarubee }
   }
   
   public func updateFixedIncome(_ id: String, fixedIncome: Int) throws {
@@ -106,7 +107,10 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     guard let model = try readById(id) else { return }
     modelContext.delete(model)    
   }
-  
+}
+
+
+extension SalaryBudgetRepositoryImpl {
   private func readById(_ id: String) throws -> SalaryBudgetDTO? {
     print("Impl:", #function)
     

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -19,42 +19,42 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
   }
   
   public func create(_ salaryBudget: Domain.SalaryBudget) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func readAll() async throws -> [Domain.SalaryBudget] {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return []
   }
   
   public func readByStartDate(_ startDate: Date) async throws -> Domain.SalaryBudget? {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return nil
   }
   
   public func updateTotalFixedIncome(_ id: String, totalFixedIncome: Int) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateFixedExpenses(_ id: String, fixedExpenses: [Domain.TransactionItem]) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateBalance(_ id: String, balance: Int) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func updateDefaultHarubee(_ id: String, defaultHarubee: Double) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   
   public func deleteById(_ id: String) async throws {
-    print("Impl: ", #function)
+    print("Impl:", #function)
     return
   }
   

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -91,16 +91,9 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
   
   public func deleteById(_ id: String) throws {
     print("Impl:", #function)
-    
-//    guard let model = try readById(id) else { return }
-    let predicate = #Predicate<SalaryBudgetDTO> { $0.identifier == id }
-    do {
-      try modelContext.delete(model: SalaryBudgetDTO.self, where: predicate)
-    } catch {
-      throw SwiftDataError.deleteError
-    }
-    
-    return
+
+    guard let model = try readById(id) else { return }
+    modelContext.delete(model)    
   }
   
   private func readById(_ id: String) throws -> SalaryBudgetDTO? {

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -12,10 +12,10 @@ import SwiftData
 
 public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
   
-  private let modelContainer: ModelContainer
+  private let modelContext: ModelContext
   
-  public init(modelContainer: ModelContainer) {
-    self.modelContainer = modelContainer
+  public init(modelContext: ModelContext) {
+    self.modelContext = modelContext
   }
   
   public func create(_ salaryBudget: Domain.SalaryBudget) async throws {

--- a/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
+++ b/Data/Sources/Repositories/Impls/SalaryBudgetRepositoryImpl.swift
@@ -53,22 +53,37 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     }
   }
   
+  public func updateSalaryBudget(
+    _ id: String,
+    fixedIncome: Int? = nil,
+    fixedExpenses: [TransactionItem]? = nil,
+    balance: Int? = nil,
+    defaultHarubee: Double? = nil
+  ) throws {
+    guard let model = try readById(id) else { return }
+    
+    if let fixedIncome = fixedIncome { model.fixedIncome = fixedIncome }
+    if let fixedExpenses = fixedExpenses {
+      model.fixedExpenses.forEach { modelContext.delete($0) }
+      model.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
+    }
+    if let balance = balance { model.balance = balance }
+    if let defaultHarubee = defaultHarubee { model.defaultHarubee = defaultHarubee }
+  }
+  
   public func updateFixedIncome(_ id: String, fixedIncome: Int) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
     model.fixedIncome = fixedIncome
-    
-    return
   }
   
   public func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) throws {
     print("Impl:", #function)
     
     guard let model = try readById(id) else { return }
+    model.fixedExpenses.forEach { modelContext.delete($0) }
     model.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
-    
-    return
   }
   
   public func updateBalance(_ id: String, balance: Int) throws {
@@ -76,8 +91,6 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     
     guard let model = try readById(id) else { return }
     model.balance = balance
-    
-    return
   }
   
   public func updateDefaultHarubee(_ id: String, defaultHarubee: Double) throws {
@@ -85,8 +98,6 @@ public final class SalaryBudgetRepositoryImpl: SalaryBudgetRepository {
     
     guard let model = try readById(id) else { return }
     model.defaultHarubee = defaultHarubee
-    
-    return
   }
   
   public func deleteById(_ id: String) throws {

--- a/Domain/Sources/Models/DailyBudget.swift
+++ b/Domain/Sources/Models/DailyBudget.swift
@@ -9,12 +9,28 @@
 import Foundation
 
 public struct DailyBudget: Identifiable {
-  public let id: String = UUID().uuidString
+  public let id: String
   public let date: Date
   public var harubee: Int?
   public var memo: [String]
   public var expense: Int?
   public var income: Int?
+  
+  public init(
+    id: String = UUID().uuidString,
+    date: Date,
+    harubee: Int? = nil,
+    memo: [String],
+    expense: Int? = nil,
+    income: Int? = nil
+  ) {
+    self.id = id
+    self.date = date
+    self.harubee = harubee
+    self.memo = memo
+    self.expense = expense
+    self.income = income
+  }
   
   static var `default`: DailyBudget {
     .init(

--- a/Domain/Sources/Models/SalaryBudget.swift
+++ b/Domain/Sources/Models/SalaryBudget.swift
@@ -9,21 +9,41 @@
 import Foundation
 
 public struct SalaryBudget: Identifiable {
-  public let id: String = UUID().uuidString
+  public let id: String
   public let startDate: Date
   public let endDate: Date
   public var fixedIncome: Int
-  public var fixedExpense: [TransactionItem]
+  public var fixedExpenses: [TransactionItem]
   public var balance: Int
   public var defaultHarubee: Double
   public var dailyBudgets: [DailyBudget]
+  
+  public init(
+    id: String = UUID().uuidString,
+    startDate: Date,
+    endDate: Date,
+    fixedIncome: Int,
+    fixedExpenses: [TransactionItem],
+    balance: Int,
+    defaultHarubee: Double,
+    dailyBudgets: [DailyBudget]
+  ) {
+    self.id = id
+    self.startDate = startDate
+    self.endDate = endDate
+    self.fixedIncome = fixedIncome
+    self.fixedExpenses = fixedExpenses
+    self.balance = balance
+    self.defaultHarubee = defaultHarubee
+    self.dailyBudgets = dailyBudgets
+  }
   
   static var `default`: SalaryBudget {
     .init(
       startDate: .init(),
       endDate: .init(),
       fixedIncome: 0,
-      fixedExpense: [],
+      fixedExpenses: [],
       balance: 0,
       defaultHarubee: 0,
       dailyBudgets: []

--- a/Domain/Sources/Models/TransactionItem.swift
+++ b/Domain/Sources/Models/TransactionItem.swift
@@ -9,10 +9,22 @@
 import Foundation
 
 public struct TransactionItem: Identifiable {
-  public let id: String = UUID().uuidString
+  public let id: String
   public var date: Date
   public var name: String
   public var price: Int
+  
+  public init(
+    id: String = UUID().uuidString,
+    date: Date,
+    name: String,
+    price: Int
+  ) {
+    self.id = id
+    self.date = date
+    self.name = name
+    self.price = price
+  }
   
   static var `default`: TransactionItem {
     .init(

--- a/Domain/Sources/Repositories/DailyBudgetRepository.swift
+++ b/Domain/Sources/Repositories/DailyBudgetRepository.swift
@@ -15,6 +15,22 @@ public protocol DailyBudgetRepository {
   /// - Returns: Optional(해당 날짜와 일치하느
   func readByDate(_ date: Date) throws -> DailyBudget?
   
+  
+  /// 변경하고 싶은 DailyBudget의 프로퍼티를 변경합니다.
+  /// - Parameters:
+  ///   - id: 변경할 DailyBudget의 ID
+  ///   - harubee: 변경할 하루비 금액
+  ///   - expence: 변경할 지출 금액
+  ///   - income: 변경할 수입 금액
+  ///   - memo: 변경할 메모 내역
+  func updateDailyBudget(
+    _ id: String,
+    harubee: UpdateValue<Int?>,
+    expence: UpdateValue<Int?>,
+    income: UpdateValue<Int?>,
+    memo: UpdateValue<[String]>
+  ) throws
+  
   /// 하루비를 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 DailyBudget의 ID

--- a/Domain/Sources/Repositories/DailyBudgetRepository.swift
+++ b/Domain/Sources/Repositories/DailyBudgetRepository.swift
@@ -13,29 +13,29 @@ public protocol DailyBudgetRepository {
   /// DB에서 특정 날짜에 해당하는 DailyBudget을 가져옵니다.
   /// - Parameter date: 날짜
   /// - Returns: Optional(해당 날짜와 일치하느
-  func readByDate(_ date: Date) async throws -> DailyBudget?
+  func readByDate(_ date: Date) throws -> DailyBudget?
   
   /// 하루비를 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 DailyBudget의 ID
   ///   - harubee: 변경할 하루비 금액
-  func updateHarubee(_ id: String, harubee: Int) async throws
+  func updateHarubee(_ id: String, harubee: Int) throws
   
   /// 지출 금액을 변경합니다
   /// - Parameters:
   ///   - id: 변경할 DailyBudget의 ID
   ///   - expense: 변경할 지출 금액
-  func updateExpense(_ id: String, expense: Int) async throws
+  func updateExpense(_ id: String, expense: Int) throws
   
   /// 수입 금액을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 DailyBudget의 ID
   ///   - income: 변경할 수입 금액
-  func updateIncome(_ id: String, income: Int) async throws
+  func updateIncome(_ id: String, income: Int) throws
   
   /// 메모 내역을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 DailyBudget의 ID
   ///   - memo: 변경할 메모 내역
-  func updateMemo(_ id: String, memo: [String]) async throws
+  func updateMemo(_ id: String, memo: [String]) throws
 }

--- a/Domain/Sources/Repositories/SalaryBudgetRepository.swift
+++ b/Domain/Sources/Repositories/SalaryBudgetRepository.swift
@@ -25,6 +25,21 @@ public protocol SalaryBudgetRepository {
   func readByStartDate(_ startDate: Date) throws -> SalaryBudget?
   
   
+  /// 변경하고싶은 SalaryBudget의 프로퍼티를 변경합니다
+  /// - Parameters:
+  ///   - id: 변경할 SalaryBudget의 ID
+  ///   - fixedIncome: 변경할 고정 수입 금액
+  ///   - fixedExpenses: 변경할 고정 지출 내역
+  ///   - balance: 변경할 잔액
+  ///   - defaultHarubee: 변경할 기본 하루비 금액
+  func updateSalaryBudget(
+    _ id: String,
+    fixedIncome: UpdateValue<Int>,
+    fixedExpenses: UpdateValue<[TransactionItem]>,
+    balance: UpdateValue<Int>,
+    defaultHarubee: UpdateValue<Double>
+  ) throws
+  
   /// 총 고정 수입 금액을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID

--- a/Domain/Sources/Repositories/SalaryBudgetRepository.swift
+++ b/Domain/Sources/Repositories/SalaryBudgetRepository.swift
@@ -12,7 +12,7 @@ public protocol SalaryBudgetRepository {
   
   /// SalaryBudget을 DB에 저장합니다.
   /// - Parameter salaryBudget: 저장할 SalaryBudget
-  func create(_ salaryBudget: SalaryBudget) async throws
+  func create(_ salaryBudget: SalaryBudget) async
   
   
   /// DB에 저장된 모든 SalaryBudget을 불러옵니다.
@@ -29,7 +29,7 @@ public protocol SalaryBudgetRepository {
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID
   ///   - totalFixedIncome: 변경할 고정 수입 금액
-  func updateTotalFixedIncome(_ id: String, totalFixedIncome: Int) async throws
+  func updateFixedIncome(_ id: String, fixedIncome: Int) async throws
   
   /// 고정 지출 내역을 변경합니다.
   /// - Parameters:

--- a/Domain/Sources/Repositories/SalaryBudgetRepository.swift
+++ b/Domain/Sources/Repositories/SalaryBudgetRepository.swift
@@ -12,45 +12,45 @@ public protocol SalaryBudgetRepository {
   
   /// SalaryBudget을 DB에 저장합니다.
   /// - Parameter salaryBudget: 저장할 SalaryBudget
-  func create(_ salaryBudget: SalaryBudget) async
+  func create(_ salaryBudget: SalaryBudget)
   
   
   /// DB에 저장된 모든 SalaryBudget을 불러옵니다.
   /// - Returns: DB에 저장된 모든 SalaryBudget
-  func readAll() async throws -> [SalaryBudget]
+  func readAll() throws -> [SalaryBudget]
   
   /// DB에서 특정 날짜에 해당하는 SalaryBudget을 가져옵니다.
   /// - Parameter startDate: 시작 날짜
   /// - Returns: Optional(시작 날짜에 해당하는 SalaryBudget)
-  func readByStartDate(_ startDate: Date) async throws -> SalaryBudget?
+  func readByStartDate(_ startDate: Date) throws -> SalaryBudget?
   
   
   /// 총 고정 수입 금액을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID
   ///   - totalFixedIncome: 변경할 고정 수입 금액
-  func updateFixedIncome(_ id: String, fixedIncome: Int) async throws
+  func updateFixedIncome(_ id: String, fixedIncome: Int) throws
   
   /// 고정 지출 내역을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID
   ///   - fixedExpenses: 변경할 고정 지출 내역
-  func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) async throws
+  func updateFixedExpenses(_ id: String, fixedExpenses: [TransactionItem]) throws
   
   /// 잔액을 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID
   ///   - balance: 변경할 잔액
-  func updateBalance(_ id: String, balance: Int) async throws
+  func updateBalance(_ id: String, balance: Int) throws
   
   /// 기본 하루비를 변경합니다.
   /// - Parameters:
   ///   - id: 변경할 SalaryBudget의 ID
   ///   - defaultHarubee: 변경할 기본 하루비 금액
-  func updateDefaultHarubee(_ id: String, defaultHarubee: Double) async throws
+  func updateDefaultHarubee(_ id: String, defaultHarubee: Double) throws
   
   
   /// DB에서 SalaryBudget을 삭제합니다.
   /// - Parameter id: 삭제할 SalaryBudget의 ID
-  func deleteById(_ id: String) async throws
+  func deleteById(_ id: String) throws
 }

--- a/Domain/Sources/Repositories/UpdateValue.swift
+++ b/Domain/Sources/Repositories/UpdateValue.swift
@@ -1,0 +1,14 @@
+//
+//  UpdateValue.swift
+//  Domain
+//
+//  Created by 이정동 on 10/30/24.
+//  Copyright © 2024 namudiEtc. All rights reserved.
+//
+
+import Foundation
+
+public enum UpdateValue<T> {
+  case set(T)
+  case keep
+}

--- a/Harubee-iOS/Sources/App/DI/RepositoryProvider.swift
+++ b/Harubee-iOS/Sources/App/DI/RepositoryProvider.swift
@@ -19,13 +19,13 @@ final class RepositoryProvider {
   
   lazy var salaryBudgetRepository: SalaryBudgetRepository = {
     SalaryBudgetRepositoryImpl(
-      modelContainer: storageProvider.modelContainer
+      modelContext: storageProvider.modelContext
     )
   }()
   
   lazy var dailyBudgetRepository: DailyBudgetRepository = {
     DailyBudgetRepositoryImpl(
-      modelContainer: storageProvider.modelContainer
+      modelContext: storageProvider.modelContext
     )
   }()
   

--- a/Harubee-iOS/Sources/App/DI/StorageProvider.swift
+++ b/Harubee-iOS/Sources/App/DI/StorageProvider.swift
@@ -13,19 +13,29 @@ import SwiftData
 final class StorageProvider {
   lazy var modelContainer: ModelContainer = {
     let schema = Schema([
-      /*
-       TODO: DTO 설정 후 주석 해제 필요
-       BudgetDTO.self,
-       DailyBudgetDTO.self,
-       TransactionItemDTO.self
-       */
+      SalaryBudgetDTO.self,
+      DailyBudgetDTO.self,
+      TransactionItemDTO.self
     ])
     
+    let configuration = ModelConfiguration(
+      schema: schema,
+      isStoredInMemoryOnly: false
+    )
+    
     do {
-      return try ModelContainer(for: schema)
+      let container = try ModelContainer(
+        for: schema,
+        configurations: configuration
+      )
+      return container
     } catch {
       fatalError("Failed to create ModelContainer: \(error)")
     }
+  }()
+  
+  lazy var modelContext: ModelContext = {
+    ModelContext(self.modelContainer)
   }()
   
   // UserDefaults 설정


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- SalaryBudgetRepositoryImpl 구현
- DailyBudgetRepositoryImpl 구현

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #64 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208636039979709

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->


## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

### 1. 기존 Repository 함수에 작성된 async 키워드 제거

SwiftData CRUD 작업 코드 자체가 비동기 작업이 아니기 때문에 제거했습니다.
Repository 함수를 호출하는 쪽에서 위 작업이 비동기 작업으로 필요한 경우 Task 내에서 실행해주면 될 거 같습니다.

### 2. Repository Update 로직에 대하여

기존에 저희가 합의한 부분은 각 프로퍼티별 업데이트 함수를 따로 만들어서 필요한 업데이트 함수만 호출하여 불필요한 업데이트를 줄이자였습니다. (모델 자체를 업데이트하는 함수로 만들면 해당 모델의 프로퍼티 타입으로 또 다른 DTO 모델이 있는 경우, 값이 변경되지 않아도 기존 값을 DB에서 삭제하고 다시 값을 할당해주는 과정이 필요하기 때문입니다.)
허나, 구현체를 구현하는 과정에서 다음과 같은 문제에 직면했습니다.

1) DB에 저장하는 경우 외에는 App 내에서 DTO 객체 대신 Entity 객체를 사용하기 때문에 해당 모델을 update 하기 위해 DB에서 DTO 객체를 찾아야 합니다. 그렇기 때문에 update 함수 내에 DB에서 해당 DTO 객체를 찾는 함수인 readById()가 추가되었습니다. 그런데 만약 둘 이상의 프로퍼티를 한번에 업데이트 하기 위해 각 프로퍼티 업데이트 함수를 호출하게되면, readById()가 중복되어 실행되게 됩니다. 즉, 업데이트를 한번에 하는 과정에서 readById()가 불필요하게 호출되는 것입니다.
그래서 다음과 같이 함수를 수정해보았습니다.
```swift
public func updateSalaryBudget(
  _ id: String,
  fixedIncome: Int? = nil,
  fixedExpenses: [TransactionItem]? = nil,
  balance: Int? = nil,
  defaultHarubee: Double? = nil
) throws {
  guard let model = try readById(id) else { return }
  
  if let fixedIncome = fixedIncome { model.fixedIncome = fixedIncome }
  if let fixedExpenses = fixedExpenses {
    model.fixedExpenses.forEach { modelContext.delete($0) }
    model.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
  }
  if let balance = balance { model.balance = balance }
  if let defaultHarubee = defaultHarubee { model.defaultHarubee = defaultHarubee }
}

// balance와 defaultHarubee만 변경
repository.updateSalaryBudget(id, balance: 10000, defaultHarubee: 1000)
```
파라미터를 모두 옵셔널 타입으로 선언하고 기본값으로 nil값을 넣어줍니다.
그리고 함수 내에서는 if let을 통해 nil이 아닌 값만 업데이트 하도록 수정해보았습니다.
위와 같이 함수를 수정하면 함수 하나로 조건에 따라 프로퍼티를 변경할 수 있기 때문에 불필요한 readById() 호출을 줄일 수 있었습니다.

2) 하지만 또 다른 문제에 직면하게 되었습니다.
SalaryBudget 모델에는 옵셔널 타입이 없어 위에 작성한 코드대로 if let을 통해 nil을 검사하여 조건적 업데이트가 가능했지만, DailyBudget은 옵셔널 타입인 프로퍼티가 존재하여 위와 같은 방식이 불가능했습니다.
그래서 enum과 제네릭을 활용해서 다음과 같이 변경해보았습니다.
```swift
public enum UpdateValue<T> {
  case set(T)
  case keep
}

public func updateDailyBudget(
  _ id: String,
  harubee: UpdateValue<Int?> = .keep,
  expence: UpdateValue<Int?> = .keep,
  income: UpdateValue<Int?> = .keep,
  memo: UpdateValue<[String]> = .keep
) throws {
  print("Impl:", #function)
  
  guard let model = try readById(id) else { return }
  
  if case .set(let harubee) = harubee { model.harubee = harubee }
  if case .set(let expense) = expence { model.expense = expense }
  if case .set(let income) = income { model.income = income }
  if case .set(let memo) = memo { model.memo = memo }
}

// harubee, income만 변경
repository.updateDailyBudget(id, harubee: .set(10000), income: .set(10000))
```
각 파라미터를 enum 타입으로, 기본값으로는 기존 nil을 기본값으로 주었던 용도인 .keep을 정의했습니다.
위와 같이 구현하면 옵셔널 타입 또한 조건을 통해 업데이트를 해줄 수 있습니다.


<br>

확인해보시고 더 좋은 방안이 있거나 위 방식이 괜찮다고 생각되시면 해당 방법으로 protocol, Impl 수정해서 올리겠습니다