### PR TITLE
[Refactor] 기본 하루비 계산 로직 수정

### DIFF
--- a/Harubee-iOS/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
+++ b/Harubee-iOS/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
@@ -52,13 +52,21 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     
     // 4. 남은 기간의 일자 개수 구하기 (오늘부터 endDate까지)
     let calendar = Calendar.current
-    let remainingDays = calendar.dateComponents([.day], from: today, to: endDate).day ?? 0
+    let remainingDays = calendar.dateComponents(
+      [.day],
+      from: today,
+      to: endDate
+    ).day ?? 0
     
     // 5. 잔액을 남은 기간의 일자 개수로 나누어 기본 하루비 설정하기
     let defaultHarubee = Double(initialBalance) / Double(remainingDays + 1)
     
     // 6. 각 날짜별로 DailyBudget 생성하기
-    let days = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+    let days = calendar.dateComponents(
+      [.day],
+      from: startDate,
+      to: endDate
+    ).day ?? 0
     
     let dailyBudgets = (0...days).compactMap { day -> DailyBudget? in
       guard let date = calendar.date(
@@ -114,7 +122,11 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     
     // 4. 남은 기간의 일자 개수 구하기
     let calendar = Calendar.current
-    let days = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+    let days = calendar.dateComponents(
+      [.day],
+      from: startDate,
+      to: endDate
+    ).day ?? 0
     
     // 5. 잔액을 예산 기간의 일자 개수로 나누어 기본 하루비 설정하기
     let defaultHarubee = Double(initialBalance) / Double(days + 1)
@@ -172,7 +184,9 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   ) throws -> SalaryBudget {
     let targetDate = (date ?? Date()).formattedDate
     
-    guard let salaryBudget = try salaryBudgetRepository.readByTargetDateContaining(targetDate) else {
+    guard let salaryBudget = try salaryBudgetRepository.readByTargetDateContaining(
+      targetDate
+    ) else {
       throw DomainError.dataNotFound
     }
     return salaryBudget
@@ -185,7 +199,9 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     let targetDate = (startDate ?? Date()).formattedDate
     
     // 2. 특정 날짜에 해당하는 SalaryBudget 가져오기
-    guard let salaryBudget = try salaryBudgetRepository.readByStartDate(targetDate) else {
+    guard let salaryBudget = try salaryBudgetRepository.readByStartDate(
+      targetDate
+    ) else {
       throw DomainError.dataNotFound
     }
     
@@ -196,8 +212,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   // TODO: updateBalance와 updateDefaultHarubee 분리 필요
   func updateBalance(
     salaryBudget: SalaryBudget,
-    newBalance: Int,
-    from date: FromDate = .now
+    newBalance: Int
   ) throws -> SalaryBudget {
     // 1. 새로운 잔액으로 업데이트하기
     let newSalaryBudget = try salaryBudgetRepository.updateBalance(
@@ -207,8 +222,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     
     // 2. 새로 업데이트된 SalaryBudget의 잔액으로 기본 하루비 다시 계산하기
     let newDefaultHarubee = self.calculateDefaultHarubee(
-      salaryBudget: newSalaryBudget,
-      from: date
+      salaryBudget: newSalaryBudget
     )
     
     // 3. SalaryBudget에 기본 하루비 업데이트하기
@@ -247,15 +261,16 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     
     // 5. 기본 하루비 다시 계산하기
     let defaultHarubee = self.calculateDefaultHarubee(
-      salaryBudget: SalaryBudget(startDate: salaryBudget.startDate,
-                                 endDate: salaryBudget.endDate,
-                                 fixedIncome: newIncome,
-                                 fixedExpenses: salaryBudget.fixedExpenses,
-                                 balance: newBalance,
-                                 defaultHarubee: salaryBudget.defaultHarubee,
-                                 dailyBudgets: salaryBudget.dailyBudgets)
+      salaryBudget: SalaryBudget(
+        startDate: salaryBudget.startDate,
+        endDate: salaryBudget.endDate,
+        fixedIncome: newIncome,
+        fixedExpenses: salaryBudget.fixedExpenses,
+        balance: newBalance,
+        defaultHarubee: salaryBudget.defaultHarubee,
+        dailyBudgets: salaryBudget.dailyBudgets
+      )
     )
-    
     
     // 6. Repository 통해 저장하기
     do {
@@ -279,8 +294,10 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     let today = Date().formattedDate
     
     // 1. 기존 오늘 날짜 이후의 고정 지출의 합계
-    let oldPostTodayTotalExpenses = salaryBudget.fixedExpenses.filter{ $0.date > today }
+    let oldPostTodayTotalExpenses = salaryBudget.fixedExpenses
+      .filter{ $0.date > today }
       .reduce(0) { $0 + $1.price }
+    
     // 2. 오늘 날짜 이후의 고정지출들의 차이(new - old)
     let postTodayDifference = expenses.filter { $0.date > today }
       .reduce(0) { $0 + $1.price } - oldPostTodayTotalExpenses
@@ -293,16 +310,17 @@ final class BudgetUseCaseImpl: BudgetUseCase {
       throw DomainError.invalidAmount
     }
     
-    
     // 5. 기본 하루비 다시 계산하기
     let defaultHarubee = self.calculateDefaultHarubee(
-      salaryBudget: SalaryBudget(startDate: salaryBudget.startDate,
-                                 endDate: salaryBudget.endDate,
-                                 fixedIncome: salaryBudget.fixedIncome,
-                                 fixedExpenses: expenses,
-                                 balance: newBalance,
-                                 defaultHarubee: salaryBudget.defaultHarubee,
-                                 dailyBudgets: salaryBudget.dailyBudgets)
+      salaryBudget: SalaryBudget(
+        startDate: salaryBudget.startDate,
+        endDate: salaryBudget.endDate,
+        fixedIncome: salaryBudget.fixedIncome,
+        fixedExpenses: expenses,
+        balance: newBalance,
+        defaultHarubee: salaryBudget.defaultHarubee,
+        dailyBudgets: salaryBudget.dailyBudgets
+      )
     )
     
     // 6. Repository 통해 저장하기
@@ -320,21 +338,18 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   }
   
   func calculateDefaultHarubee(
-    salaryBudget: SalaryBudget,
-    from date: FromDate = .now
+    salaryBudget: SalaryBudget
   ) -> Double {
     
-    let currentDate = calendar.date(
-      from:calendar.dateComponents(
-        [.year, .month, .day],
-        from: date == .now ? Date() : Date().addingTimeInterval(86400)
-      )
-    )!
+    let currentDate = Date().formattedDate
+    
     var nilCount = 0.0
     var newBalance = Double(salaryBudget.balance)
     
     for dailyBudget in salaryBudget.dailyBudgets {
-      if dailyBudget.date < currentDate { continue }
+      if dailyBudget.date < currentDate || dailyBudget.expense != nil {
+        continue
+      }
       
       if let harubee = dailyBudget.harubee { newBalance -= Double(harubee) }
       else { nilCount += 1 }
@@ -361,7 +376,9 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     date: Date
   ) throws -> DailyBudget {
     // 1. 오늘에 해당하는 DailyBudget 찾기
-    guard let budget = try dailyBudgetRepository.readByDate(date.formattedDate) else {
+    guard let budget = try dailyBudgetRepository.readByDate(
+      date.formattedDate
+    ) else {
       throw DomainError.dataNotFound
     }
     
@@ -436,13 +453,6 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     // 5. 지출, 수입 입력 시점에 DailyBudget의 하루비가 nil인 경우, 기본 하루비로 저장
     let harubee = salaryBudget.dailyBudgets[index].harubee ?? Int(salaryBudget.defaultHarubee)
       
-    
-    // 6. DailyBudget 업데이트 (실제 지출, 수입 기록)
-//    let newDailyBudget = try dailyBudgetRepository.updateTransaction(
-//      salaryBudget.dailyBudgets[index].id,
-//      expense: currentExpense,
-//      income: currentIncome
-//    )
     let newDailyBudget = try dailyBudgetRepository.updateDailyBudget(
       salaryBudget.dailyBudgets[index].id,
       harubee: .set(harubee),
@@ -454,13 +464,10 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     // 7. 잔액 업데이트
     let newBalance = salaryBudget.balance - diffExpense + diffIncome
     
-    
-    // TODO: 수정 필요
     // 8. SalaryBudget 업데이트
     let newSalaryBudget = try self.updateBalance(
       salaryBudget: salaryBudget,
-      newBalance: newBalance,
-      from: currentExpense == 0 ? .now : .tomorrow
+      newBalance: newBalance
     )
     
     return (newDailyBudget, newSalaryBudget)
@@ -495,28 +502,47 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     
     // 3. 새로운 SalaryBudget을 위한 데이트 계산하기
     var incomeStartDate: Date {
-      var components = calendar.dateComponents([.year, .month, .day], from: today)
+      var components = calendar.dateComponents(
+        [.year, .month, .day],
+        from: today
+      )
+      
       if components.day! < day {
         components.month! -= 1
       }
+      
       components.day! = day
+      
       let startDate = calendar.date(from: components)!
+      
       return startDate
     }
     
     var incomeEndDate: Date {
       // startDate가 한 달의 시작 날짜가 됩니다.
       let startDate = incomeStartDate
+      
       // startDate의 일자(day)를 기준으로 한 달 후의 날짜를 구함
-      var components = calendar.dateComponents([.year, .month, .day], from: startDate)
+      var components = calendar.dateComponents(
+        [.year, .month, .day],
+        from: startDate
+      )
+      
       components.month! += 1 // 한 달 뒤로 설정
+      
       // 다음 달에 동일한 일자가 있는지 확인하여 날짜를 생성
       if let calculatedEndDate = calendar.date(from: components) {
         return calculatedEndDate.addingTimeInterval(-86400)
       } else {
         // 동일 일자가 없는 경우(예: 30일이나 31일이 없는 달) 해당 월의 마지막 날로 조정
         var fallbackComponents = components
-        fallbackComponents.day = calendar.range(of: .day, in: .month, for: calendar.date(from: components)!)?.last
+        
+        fallbackComponents.day = calendar.range(
+          of: .day,
+          in: .month,
+          for: calendar.date(from: components)!
+        )?.last
+        
         return calendar.date(from: fallbackComponents)!
       }
     }
@@ -525,10 +551,12 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     try salaryBudgetRepository.deleteById(salaryBudget.id)
     
     // 5. 새로운 SalaryBudget 생성
-    return try self.createSalaryBudget(startDate: incomeStartDate,
-                                       endDate: incomeEndDate,
-                                       fixedIncome: salaryBudget.fixedIncome,
-                                       fixedExpenses: salaryBudget.fixedExpenses)
+    return try self.createSalaryBudget(
+      startDate: incomeStartDate,
+      endDate: incomeEndDate,
+      fixedIncome: salaryBudget.fixedIncome,
+      fixedExpenses: salaryBudget.fixedExpenses
+    )
   }
   
   

--- a/Harubee-iOS/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
+++ b/Harubee-iOS/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-enum FromDate {
-  case now
-  case tomorrow
-}
-
 protocol BudgetUseCase {
   
   func createSalaryBudgetFromOnboarding(
@@ -74,8 +69,7 @@ protocol BudgetUseCase {
   ///   - `DomainError.dataNotFound`: SalaryBudget을 찾을 수 없는 경우
   func updateBalance(
     salaryBudget: SalaryBudget,
-    newBalance: Int,
-    from date: FromDate
+    newBalance: Int
   ) throws -> SalaryBudget
   
   
@@ -117,8 +111,7 @@ protocol BudgetUseCase {
   ///   - salaryBudget: 조정된 하루비들을 확인하기 위한 SalaryBudget
   /// - Returns: 계산된 기본 하루비
   func calculateDefaultHarubee(
-    salaryBudget: SalaryBudget,
-    from date: FromDate
+    salaryBudget: SalaryBudget
   ) -> Double
   
   

--- a/Harubee-iOS/Sources/Presentation/Common/ViewModels/HarubeeAdjustViewModel.swift
+++ b/Harubee-iOS/Sources/Presentation/Common/ViewModels/HarubeeAdjustViewModel.swift
@@ -65,8 +65,7 @@ extension HarubeeAdjustViewModel {
     }
     
     let defaultHarubee = self.budgetUseCase.calculateDefaultHarubee(
-      salaryBudget: self.state.salaryBudget,
-      from: .now
+      salaryBudget: self.state.salaryBudget
     )
     
     self.state.salaryBudget.defaultHarubee = defaultHarubee


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [x] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
기본 하루비 계산 로직을 수정합니다.

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #137 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208744589470637

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 1. 13일(과거 날짜)의 지출 금액을 5만원으로 입력 후 다시 0원으로 입력
        → 14~18일까지의 기본 하루비가 9만원으로 변경된 후 다시 10만원으로 돌아옴
- [x] 2. 14일(오늘 날짜)의 하루비를 14만원으로 조정
        → 15~18일까지의 기본 하루비가 9만원으로 변경됨
- [x] 3. 14일(오늘 날짜)의 지출 금액을 6만원으로 저장
        → 하루비보다 8만원 덜 썼으므로, 15~18일에 2만원씩 분배되면서 기본 하루비가 11만원으로 변경됨
- [x] 4. 14일(오늘 날짜)의 지출 금액을 2만원으로 저장
         → 전에 입력한 지출보다 4만원 적게 입력했으므로, 15~18일에 1만원씩 분배되면서 기본 하루비가 12만원으로 변경됨
- [x] 5. 15일(미래 날짜)의 하루비를 15만원으로 변경
         → 16~18일의 하루비가 11만원으로 변경됨

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|테스트 1번|<img src = "https://github.com/user-attachments/assets/45b58bba-4fd2-49aa-8a5a-bad13fa332e5" width ="250"> <img src = "https://github.com/user-attachments/assets/25205191-5900-4a42-8285-a2b9ab6f80b1" width ="250">|
|테스트 2번|<img src = "https://github.com/user-attachments/assets/4a388c0a-d6ea-48ab-a12d-9acc282de83e" width ="250">|
|테스트 3번|<img src = "https://github.com/user-attachments/assets/ed716b84-dd4a-4b19-a819-ed0eb53e8341" width ="250">|
|테스트 4번|<img src = "https://github.com/user-attachments/assets/bc485515-c32f-412d-9c90-9188fa89b300" width ="250">|
|테스트 5번|<img src = "https://github.com/user-attachments/assets/2a301702-3fae-4819-abf2-72fc16c61929" width ="250">|


## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

기본 하루비 계산 과정에서 오늘 날짜부터 마지막 날짜까지 DailyBudget을 순회할 때, 해당 날짜에 지출 내역이 있을 경우에는 기본 하루비 계산 과정에서 제외시켰습니다.

이유
1. 지출을 입력한 시점부터는 하루비보다 얼마 더 썼다, 덜 썼다가 판별이 됨.
2. 하루비와 실제 지출의 차액만큼 해당 날짜를 제외한 나머지 날짜의 기본 하루비에 분배를 해야함.
3. 이미 지출을 입력한 시점에 SalaryBudget의 balance는 해당 금액만큼 차감이 되고, DailyBudget의 harubee는 값이 들어가게 되므로 기본 하루비 계산 대상에서 제외됨.

```swift
func calculateDefaultHarubee(
  salaryBudget: SalaryBudget
) -> Double {
  
  let currentDate = Date().formattedDate
  
  var nilCount = 0.0
  var newBalance = Double(salaryBudget.balance)
  
  for dailyBudget in salaryBudget.dailyBudgets {
    // 해당 DailyBudget에 지출 내역이 존재하는지 확인하는 조건 추가
    if dailyBudget.date < currentDate || dailyBudget.expense != nil {
      continue
    }
    
    if let harubee = dailyBudget.harubee { newBalance -= Double(harubee) }
    else { nilCount += 1 }
  }
  
  return nilCount == 0.0 ? newBalance : newBalance / nilCount
}
```