### PR TITLE
[Hotfix] TodayView 날짜 레이블 애니메이션 버그 수정

### DIFF
--- a/Harubee/Sources/Presentation/Today/Views/TodayView.swift
+++ b/Harubee/Sources/Presentation/Today/Views/TodayView.swift
@@ -262,6 +262,7 @@ private struct HarubeeHexagon: View {
         if isTodayHarubee {
           harubeeNumberContainer
             .padding(.top, 11)
+            .animation(.easeInOut(duration: 1.5), value: animatedFillPercentage)
         } else {
           balanceNumberContainer
             .padding(.top, 13)

--- a/Harubee/Sources/Presentation/Today/Views/TodayView.swift
+++ b/Harubee/Sources/Presentation/Today/Views/TodayView.swift
@@ -257,6 +257,7 @@ private struct HarubeeHexagon: View {
           .infoBubble(isVisible: $isInfoBubbleVisible) {
             infoBubbleText
           }
+          .animation(.easeInOut(duration: 1.5), value: animatedFillPercentage)
         
         if isTodayHarubee {
           harubeeNumberContainer

--- a/Harubee/Sources/Presentation/Today/Views/TodayView.swift
+++ b/Harubee/Sources/Presentation/Today/Views/TodayView.swift
@@ -230,11 +230,13 @@ private struct HarubeeHexagon: View {
         .fill(isTodayHarubee ? Color.textBrighter : Color.textBlack30)
         .frame(width: hexgonSize, height: hexgonSize)
         .clipShape(RoundedHexagon())
+        .animation(.easeInOut(duration: 1.5), value: animatedFillPercentage)
       
       Wave(xOffset: secondWaveOffset, fillPercentage: animatedFillPercentage)
         .fill(isTodayHarubee ? Color.whiteDefault :  Color.mainBright)
         .frame(width: hexgonSize, height: hexgonSize)
         .clipShape(RoundedHexagon())
+        .animation(.easeInOut(duration: 1.5), value: animatedFillPercentage)
       
       RoundedHexagon()
         .stroke(Color.whiteDefault, lineWidth: 1.5)
@@ -281,9 +283,7 @@ private struct HarubeeHexagon: View {
       }
     }
     .onChange(of: fillPercentage) { _, newPercentage in
-      withAnimation(.easeInOut(duration: 1.5)) {
-        animatedFillPercentage = CGFloat(newPercentage)
-      }
+      animatedFillPercentage = CGFloat(newPercentage)
     }
     .sheet(isPresented: $isPresented) {
       todayViewModel.send(.viewDidLoad)


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [x] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
날짜 레이블이 애니메이션되는 버그를 수정했습니다.

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #161 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208831028270658

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 수정된 버그 확인

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

## 문제 발견
문제는 앱을 처음 실행했을 때, TodayView의 애니메이션이 의도하지 않은 날짜 레이블에도 같이 실행되는 문제입니다. 
특징은 시뮬레이터에서는 문제가 발생하지 않는데, 실 기기에서는 문제가 발생한다는 점입니다.

https://github.com/user-attachments/assets/8466cab0-314b-41a7-91e9-a643a120aa44

이렇게 `Wave` 뷰의 애니메이션과 함께 날짜 레이블도 움직입니다. 
근데 또 시뮬레이터에서는 동일한 코드로 실행하더라도 문제가 발생하지 않았습니다.

## 문제 원인 분석
먼저, TodayView 내부에서 애니메이션을 트리거하는 상태는 `animatedFillPercentage` 뿐입니다.
따라서 이 애니메이션 동작(`withAnimation`)을 제거하면 문제는 발생하지 않았습니다.

애니메이션이 문제라는 걸 알았으니, 이 애니메이션이 어떻게 동작하는지 확인해봤습니다.
일단 이 `animatedFillPercentage` 상태를 사용하는 뷰는 

`Wave`, `hexagonLabel`, `harubeeNumberContainer` 뷰 뿐입니다.
날짜 레이블을 가지고 있는 `TodayHeaderView`에서는 뷰모델만 파라미터로 받을 뿐, 애니메이션에 관련된 코드는 존재하지 않았습니다.

```swift
private struct TodayHeaderView: View {
  
  let todayViewModel: TodayViewModel
  
  var body: some View {
    HStack {
      Text(todayViewModel.state.todayDate.formattedDateToString(.fullDate_kr))
        .font(.pretendardSemibold_14)
        .foregroundStyle(Color.whiteDefault)
    }.frame(maxWidth: .infinity, alignment: .trailing)
      .padding(.trailing, 16)
      .padding(.top, 6)
  }
}
```

[withAnimation의 공식 문서](https://developer.apple.com/documentation/swiftui/withanimation(_:_:)) 내용을 살펴보면, [Managing user interface state](https://developer.apple.com/documentation/swiftui/managing-user-interface-state) 라는 문서를 멘션하는데 이 문서에서는 상태 변경과 애니메이션에 관해 다음과 같이 설명하고 있습니다.

> When the view state changes, SwiftUI updates affected views right away. If you want to smooth visual transitions, you can tell SwiftUI to animate them by wrapping the state change that triggers them in a call to the withAnimation(_:_:) function.
> ...
> Either way, SwiftUI animates any view changes that happen when the underlying stored value changes. 
>
> 뷰 상태가 변경되면 SwiftUI가 영향을 받는 뷰를 즉시 업데이트합니다. 시각적 전환을 부드럽게 하려면 트리거하는 상태 변경을 `withAnimation(_:_:)` 함수 호출로 래핑하여 SwiftUI에 애니메이션을 적용하도록 지시할 수 있습니다.
> ...
> 어느 쪽이든 SwiftUI에서는 기본 저장된 값이 변경될 때 발생하는 모든 뷰 변경에 애니메이션을 적용합니다.

즉, `withAnimation`을 사용하면 트리거하는 상태에 영향을 받는 모든 뷰 변경에 애니메이션을 적용한다는걸 알 수 있습니다. 

우리는 `Wave` 뷰에만 애니메이션을 적용하고자 했는데, 날짜 레이블에도 애니메이션이 적용되니 날짜 레이블이 알게 모르게 `animatedFillPercentage` 상태에 영향을 받는다는걸 알 수 있습니다.

이를 한 번 테스트해보고자 `TodaySecondaryLayerView`에서 `Spacer()`를 제거하고 실행해보았습니다.

https://github.com/user-attachments/assets/29e0eb8f-0f2b-43be-87cb-5c7c94559cf8

이 영상을 보면, 날짜 레이블뿐만 아니라 `TodaySecondaryLayerView` 자체에도 애니메이션이 적용되는 모습을 볼 수 있습니다.

결국 `withAnimation` 블록의 애니메이션 적용 범위를 정확히 알기 어려워, 
애니메이션을 적용하고자 하는 뷰에만 `.animation` 모디파이어로 적용하기로 했습니다.

## 해결 방법
애니메이션을 적용할 `Wave`, `hexagonLabel`, `harubeeNumberContainer` 뷰에만,
`.animation(.easeInOut(duration: 1.5), value: animatedFillPercentage)` 모디파이어를 설정했습니다. 

https://github.com/user-attachments/assets/90193365-7c84-41c2-80e4-c0696a686c10

이후 테스트 결과 시뮬레이터와 실제 기기 모두에서 날짜 레이블은 애니메이션되지 않고 애니메이션이 되어야할 뷰만 애니메이션이 잘 작동했습니다.