### PR TITLE
[Feature] OnboardingView UI 수정

### DIFF
--- a/Harubee/Resources/Colors.xcassets/Placeholder.colorset/Contents.json
+++ b/Harubee/Resources/Colors.xcassets/Placeholder.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.600",
+          "alpha" : "0.300",
           "blue" : "0x43",
           "green" : "0x3C",
           "red" : "0x3C"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.600",
+          "alpha" : "0.300",
           "blue" : "0xF5",
           "green" : "0xEB",
           "red" : "0xEB"

--- a/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
+++ b/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
@@ -30,7 +30,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   func createSalaryBudgetFromOnboarding(
     startDate: Date,
     endDate: Date,
-    previousExpense: Int?,
+    currentBalance: Int?,
     fixedIncome: Int,
     fixedExpenses: [TransactionItem]
   ) throws -> SalaryBudget {
@@ -39,16 +39,11 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     let endDate = endDate.formattedDate
     let today = Date().formattedDate
     
-    // 2. 총 고정 지출 금액 계산하기
-    let totalFixedExpenses = fixedExpenses.reduce(0) { $0 + $1.price }
+    // 2. 앞으로 예정된 고정 지출 금액 계산하기
+    let totalFixedExpenses = fixedExpenses.filter { $0.date > today }.reduce(0) { $0 + $1.price }
     
-    // 3. 고정 수입에서 고정 지출을 뺀 금액 잔액으로 설정하기
-    var initialBalance = fixedIncome - totalFixedExpenses
-    
-    // 3-1. 만약 이전 지출 금액을 받은 경우 잔액 다시 계산하기
-    if let previousExpense {
-      initialBalance -= previousExpense
-    }
+    // 3. 사용자가 입력한 잔액에서 앞으로 예정된 고정 지출 금액 빼기
+    let initialBalance = currentBalance! - totalFixedExpenses
     
     // 4. 남은 기간의 일자 개수 구하기 (오늘부터 endDate까지)
     let calendar = Calendar.current

--- a/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
+++ b/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
@@ -13,7 +13,7 @@ protocol BudgetUseCase {
   func createSalaryBudgetFromOnboarding(
     startDate: Date,
     endDate: Date,
-    previousExpense: Int?,
+    currentBalance: Int?,
     fixedIncome: Int,
     fixedExpenses: [TransactionItem]
   ) throws -> SalaryBudget
@@ -22,7 +22,7 @@ protocol BudgetUseCase {
   /// - Parameters:
   ///   - startDate: SalaryBudget 시작일
   ///   - endDate: SalaryBudget 종료일
-  ///   - previousExpense: 온보딩 시 이전 지출 금액
+  ///   - currentBalance: 온보딩 시 현재 잔액
   ///   - fixedIncome: 고정 수입 금액
   ///   - fixedExpenses: 고정 지출 항목 배열
   /// - Returns: 생성된 SalaryBudget 객체

--- a/Harubee/Sources/Helper/Manageres/KeyboardObserverManager.swift
+++ b/Harubee/Sources/Helper/Manageres/KeyboardObserverManager.swift
@@ -30,6 +30,10 @@ final class KeyboardObserverManager {
     )
   }
   
+  func hideKeyboard() {
+    UIApplication.shared.endEditing()
+  }
+  
   @objc private func keyboardWillShow() {
     isKeyboardVisible = true
   }

--- a/Harubee/Sources/Presentation/Common/Components/DayPickerView.swift
+++ b/Harubee/Sources/Presentation/Common/Components/DayPickerView.swift
@@ -27,7 +27,7 @@ struct DayPickerView: View {
   let titleFont: TitleFont
   
   @State private var keyboardObserver = KeyboardObserverManager()
-  @State private var showDayPicker: Bool = false
+  @Binding var showDayPicker: Bool
   @Binding var selectedDay: Int
   
   var body: some View {

--- a/Harubee/Sources/Presentation/Common/Components/DayPickerView.swift
+++ b/Harubee/Sources/Presentation/Common/Components/DayPickerView.swift
@@ -26,7 +26,6 @@ struct DayPickerView: View {
   let title: String
   let titleFont: TitleFont
   
-  @State private var keyboardObserver = KeyboardObserverManager()
   @Binding var showDayPicker: Bool
   @Binding var selectedDay: Int
   
@@ -43,13 +42,6 @@ struct DayPickerView: View {
         )
       }
       .padding(.horizontal, 20)
-      .onChange(
-        of: keyboardObserver.isKeyboardVisible
-      ) { _, newValue in
-        if newValue {
-          showDayPicker = false
-        }
-      }
       
       if showDayPicker { dayPicker }
     }

--- a/Harubee/Sources/Presentation/Common/Components/FloatingTitleTextField.swift
+++ b/Harubee/Sources/Presentation/Common/Components/FloatingTitleTextField.swift
@@ -22,7 +22,7 @@ struct FloatingTitleTextField: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .foregroundStyle(
           !text.isEmpty
-          ? (isTextfieldFocused ? Color.main : Color.textBright)
+          ? (isTextfieldFocused ? .main : .textBright)
           : .clear
         )
         .offset(y: !text.isEmpty ? -4 : 0)
@@ -39,8 +39,8 @@ struct FloatingTitleTextField: View {
         .frame(height: !isTextfieldFocused ? 1 : 2)
         .foregroundStyle(
           !isTextfieldFocused
-          ? Color.textBrighter
-          : Color.main
+          ? .textBrighter
+          : .mainBright
         )
         .padding(.top, !isTextfieldFocused ? 8 : 7)
     }
@@ -95,7 +95,7 @@ struct FloatingTitleNumberField: View {
       Rectangle()
         .frame(height: isFocused ? 2 : 1)
         .foregroundStyle(
-          isFocused ? .main : .textBrighter
+          isFocused ? .mainBright : .textBrighter
         )
         .padding(.top, isFocused ? 7 : 8)
     }

--- a/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
+++ b/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
@@ -73,6 +73,7 @@ struct FixedExpenseManageView: View {
           self.dismiss()
         }
       }
+      .ignoresSafeArea(.keyboard)
       
       if isNumberFieldFocused {
         NumberKeypadView(amount: $fixedExpenseAmount) {
@@ -80,6 +81,7 @@ struct FixedExpenseManageView: View {
         }
       }
     }
+    
     .onChange(of: selectedDay) { _, newValue in
       if mode == .modify {
         if beforeSelectedDay == newValue {

--- a/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
+++ b/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
@@ -31,7 +31,7 @@ struct FixedExpenseManageView: View {
   @State private var fixedExpenseName: String
   @State private var fixedExpenseAmount: String
   @State private var isEnabled: Bool = false
-  @State private var showDayPicker: Bool = false
+  @State private var isNumberFieldFocused: Bool = false
   
   private let beforeSelectedDay: Int
   
@@ -59,7 +59,7 @@ struct FixedExpenseManageView: View {
           fixedExpenseName: $fixedExpenseName,
           fixedExpenseAmount: $fixedExpenseAmount,
           selectedDay: $selectedDay,
-          showDayPicker: $showDayPicker
+          isNumberFieldFocused: $isNumberFieldFocused
         )
         .padding(.top, 37)
         
@@ -73,23 +73,29 @@ struct FixedExpenseManageView: View {
           self.dismiss()
         }
       }
-      .onChange(of: selectedDay) { _, newValue in
-        if mode == .modify {
-          if beforeSelectedDay == newValue {
-            isEnabled = false
-          } else {
-            updateIsEnabled()
-          }
+      
+      if isNumberFieldFocused {
+        NumberKeypadView(amount: $fixedExpenseAmount) {
+          self.isNumberFieldFocused = false
+        }
+      }
+    }
+    .onChange(of: selectedDay) { _, newValue in
+      if mode == .modify {
+        if beforeSelectedDay == newValue {
+          isEnabled = false
         } else {
           updateIsEnabled()
         }
-      }
-      .onChange(of: fixedExpenseName) { _, _ in
+      } else {
         updateIsEnabled()
       }
-      .onChange(of: fixedExpenseAmount) { _, _ in
-        updateIsEnabled()
-      }
+    }
+    .onChange(of: fixedExpenseName) { _, _ in
+      updateIsEnabled()
+    }
+    .onChange(of: fixedExpenseAmount) { _, _ in
+      updateIsEnabled()
     }
   }
   
@@ -105,10 +111,13 @@ struct FixedExpenseManageView: View {
 }
 
 private struct BodyView: View {
+  @State private var keyboardObserver = KeyboardObserverManager()
   @Binding var fixedExpenseName: String
   @Binding var fixedExpenseAmount: String
   @Binding var selectedDay: Int
-  @Binding var showDayPicker: Bool
+  @Binding var isNumberFieldFocused: Bool
+  
+  @State private var showDayPicker: Bool = false
   
   var body: some View {
     VStack(spacing: 0) {
@@ -126,16 +135,36 @@ private struct BodyView: View {
       .padding(.horizontal, 16)
       .padding(.top, 20)
       
-      FloatingTitleTextField(
+      FloatingTitleNumberField(
         title: "금액",
-        text: $fixedExpenseAmount
+        textSize: .medium,
+        text: $fixedExpenseAmount,
+        isFocused: $isNumberFieldFocused
       )
       .padding(.horizontal, 16)
       .padding(.top, 22)
-      .keyboardType(.numberPad)
+      .onTapGesture {
+        showDayPicker = false
+        keyboardObserver.hideKeyboard()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          isNumberFieldFocused = true
+        }
+      }
     }
     .onChange(of: fixedExpenseAmount) { _, _ in
       fixedExpenseAmount = (fixedExpenseAmount.numberFormat ?? 0).decimal
+    }
+    .onChange(of: keyboardObserver.isKeyboardVisible) {
+      if $1 {
+        self.showDayPicker = false
+        self.isNumberFieldFocused = false
+      }
+    }
+    .onChange(of: showDayPicker) {
+      if $1 {
+        self.isNumberFieldFocused = false
+        keyboardObserver.hideKeyboard()
+      }
     }
   }
 }

--- a/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
+++ b/Harubee/Sources/Presentation/Common/Views/FixedExpenseManageView.swift
@@ -31,6 +31,7 @@ struct FixedExpenseManageView: View {
   @State private var fixedExpenseName: String
   @State private var fixedExpenseAmount: String
   @State private var isEnabled: Bool = false
+  @State private var showDayPicker: Bool = false
   
   private let beforeSelectedDay: Int
   
@@ -50,42 +51,45 @@ struct FixedExpenseManageView: View {
   }
   
   var body: some View {
-    VStack(spacing: 0) {
-      BottomSheetHeaderView(title: "고정지출 내역 \(mode.title)")
-      
-      BodyView(
-        fixedExpenseName: $fixedExpenseName,
-        fixedExpenseAmount: $fixedExpenseAmount,
-        selectedDay: $selectedDay
-      )
+    ZStack(alignment: .bottom) {
+      VStack(spacing: 0) {
+        BottomSheetHeaderView(title: "고정지출 내역 \(mode.title)")
+        
+        BodyView(
+          fixedExpenseName: $fixedExpenseName,
+          fixedExpenseAmount: $fixedExpenseAmount,
+          selectedDay: $selectedDay,
+          showDayPicker: $showDayPicker
+        )
         .padding(.top, 37)
-      
-      Spacer()
-      
-      MainColorBottomButton(
-        title: "저장하기",
-        isEnabled: $isEnabled
-      ) {
-        self.action(selectedDay, fixedExpenseName, fixedExpenseAmount)
-        self.dismiss()
+        
+        Spacer()
+        
+        MainColorBottomButton(
+          title: "저장하기",
+          isEnabled: $isEnabled
+        ) {
+          self.action(selectedDay, fixedExpenseName, fixedExpenseAmount)
+          self.dismiss()
+        }
       }
-    }
-    .onChange(of: selectedDay) { _, newValue in
-      if mode == .modify {
-        if beforeSelectedDay == newValue {
-          isEnabled = false
+      .onChange(of: selectedDay) { _, newValue in
+        if mode == .modify {
+          if beforeSelectedDay == newValue {
+            isEnabled = false
+          } else {
+            updateIsEnabled()
+          }
         } else {
           updateIsEnabled()
         }
-      } else {
+      }
+      .onChange(of: fixedExpenseName) { _, _ in
         updateIsEnabled()
       }
-    }
-    .onChange(of: fixedExpenseName) { _, _ in
-      updateIsEnabled()
-    }
-    .onChange(of: fixedExpenseAmount) { _, _ in
-      updateIsEnabled()
+      .onChange(of: fixedExpenseAmount) { _, _ in
+        updateIsEnabled()
+      }
     }
   }
   
@@ -104,12 +108,14 @@ private struct BodyView: View {
   @Binding var fixedExpenseName: String
   @Binding var fixedExpenseAmount: String
   @Binding var selectedDay: Int
+  @Binding var showDayPicker: Bool
   
   var body: some View {
     VStack(spacing: 0) {
       DayPickerView(
         title: "날짜",
         titleFont: .view,
+        showDayPicker: $showDayPicker,
         selectedDay: $selectedDay
       )
       
@@ -117,16 +123,16 @@ private struct BodyView: View {
         title: "이름",
         text: $fixedExpenseName
       )
-        .padding(.horizontal, 16)
-        .padding(.top, 20)
+      .padding(.horizontal, 16)
+      .padding(.top, 20)
       
       FloatingTitleTextField(
         title: "금액",
         text: $fixedExpenseAmount
       )
-        .padding(.horizontal, 16)
-        .padding(.top, 22)
-        .keyboardType(.numberPad)
+      .padding(.horizontal, 16)
+      .padding(.top, 22)
+      .keyboardType(.numberPad)
     }
     .onChange(of: fixedExpenseAmount) { _, _ in
       fixedExpenseAmount = (fixedExpenseAmount.numberFormat ?? 0).decimal

--- a/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -13,7 +13,7 @@ final class OnboardingViewModel {
   struct State {
     var incomeDay: Int = 1 // 고정 수입일
     var incomeAmount: Int? // 한달 수입금
-    var previousExpense: Int? // 수입일 이후 지출 금액
+    var currentBalance: Int? // 현재 잔액
     var fixedExpenses: [TransactionItem] = [] // 고정 지출 내역
     var averageHarubee: Int = 0 // 평균 하루비
     
@@ -58,7 +58,7 @@ final class OnboardingViewModel {
     case updateFixedIncomeDay(Int)
     case updateFixedIncomeAmount(Int)
     case updateFixedExpenses([TransactionItem])
-    case updatePreviousExpense(Int)
+    case updateCurrentBalance(Int)
     case finishOnboardingSetting
   }
   
@@ -81,14 +81,14 @@ final class OnboardingViewModel {
     case let .updateFixedExpenses(fixedExpenses):
       self.state.fixedExpenses = fixedExpenses
       
-    case let .updatePreviousExpense(previousExpense):
-      self.state.previousExpense = previousExpense
+    case let .updateCurrentBalance(currentBalance):
+      self.state.currentBalance = currentBalance
       
     case .finishOnboardingSetting:
       let _ = try? budgetUseCase.createSalaryBudgetFromOnboarding(
         startDate: self.state.incomeStartDate,
         endDate: self.state.incomeEndDate,
-        previousExpense: self.state.previousExpense,
+        currentBalance: self.state.currentBalance,
         fixedIncome: self.state.incomeAmount ?? 0,
         fixedExpenses: self.state.fixedExpenses
       )
@@ -101,8 +101,7 @@ final class OnboardingViewModel {
 extension OnboardingViewModel {
   private func calculateAverageHarubee() -> Int {
     let balance = calculateBalance(
-      incomeAmount: self.state.incomeAmount ?? 0,
-      previousExpense: self.state.previousExpense ?? 0,
+      currentBalance: self.state.currentBalance ?? 0,
       fixedExpenses: self.state.fixedExpenses
     )
     
@@ -115,12 +114,11 @@ extension OnboardingViewModel {
   }
   
   private func calculateBalance(
-    incomeAmount: Int,
-    previousExpense: Int,
+    currentBalance: Int,
     fixedExpenses: [TransactionItem]
   ) -> Int {
     let now = Date().formattedDate
     let totalExpenses = fixedExpenses.filter { $0.date > now }.reduce(0) { $0 + $1.price }
-    return incomeAmount - previousExpense - totalExpenses
+    return currentBalance - totalExpenses
   }
 }

--- a/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -55,6 +55,7 @@ final class OnboardingViewModel {
   }
   
   enum Action {
+    case onAppearOnboardingStep3
     case updateFixedIncomeDay(Int)
     case updateFixedIncomeAmount(Int)
     case updateFixedExpenses([TransactionItem])
@@ -72,6 +73,10 @@ final class OnboardingViewModel {
   
   func send(_ action: Action) {
     switch action {
+    case .onAppearOnboardingStep3:
+      if self.state.currentBalance == nil {
+        self.state.currentBalance = self.state.incomeAmount ?? 0
+      }
     case let .updateFixedIncomeDay(day):
       self.state.incomeDay = day
       

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
@@ -125,7 +125,7 @@ private struct CalculateContentView: View {
         .padding(.leading, 4)
         .padding(.top, 22)
       
-      Text("(나의 수입 - 고정지출) ÷ 다음 주요 수입일까지 남은 일수")
+      Text("(잔액 - 예정된 고정지출) ÷ 다음 주요 수입일까지 남은 일수")
         .font(.pretendardSemibold_14)
         .foregroundStyle(.whiteDefault)
         .frame(maxWidth: .infinity)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
@@ -20,13 +20,13 @@ struct Onboarding2View: View {
     ZStack {
       Color.main.ignoresSafeArea()
       VStack(spacing: 0) {
-        TitleView()
+        titleView
         
-        HarubeeExplainView()
+        harubeeExplainView
         .padding(.horizontal, 16)
         .padding(.top, 12)
         
-        CalculateContentView()
+        calculateContentView
           .padding(.top, 73)
           .padding(.horizontal, 16)
         Spacer()
@@ -57,10 +57,8 @@ struct Onboarding2View: View {
       }
     }
   }
-}
-
-private struct TitleView: View {
-  var body: some View {
+  
+  private var titleView: some View {
     VStack(alignment: .leading, spacing: 6) {
       HStack(spacing: 4) {
         Image(.harubeeWhite)
@@ -76,10 +74,8 @@ private struct TitleView: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, 20)
   }
-}
-
-private struct HarubeeExplainView: View {
-  var body: some View {
+  
+  private var harubeeExplainView: some View {
     VStack(spacing: 22) {
       Rectangle()
         .frame(height: 1)
@@ -108,10 +104,8 @@ private struct HarubeeExplainView: View {
       .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
-}
-
-private struct CalculateContentView: View {
-  var body: some View {
+  
+  private var calculateContentView: some View {
     VStack(spacing: 0) {
       Rectangle()
         .frame(height: 1)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -29,7 +29,7 @@ struct Onboarding3View: View {
   var body: some View {
     ZStack(alignment: .bottom) {
       VStack(spacing: 0) {
-        OnboardingHeaderView()
+        onboardingHeaderView
         
         OnboardingBodyView(
           incomeDay: $incomeDay,
@@ -70,10 +70,8 @@ struct Onboarding3View: View {
         .navigationBarBackButtonHidden()
     }
   }
-}
-
-private struct OnboardingHeaderView: View {
-  var body: some View {
+  
+  private var onboardingHeaderView: some View {
     VStack(spacing: 30) {
       OnboardingNavigationHeaderView(onboardingPage: .first)
       
@@ -90,6 +88,7 @@ private struct OnboardingHeaderView: View {
     .background(
       Rectangle().fill(Color.main).ignoresSafeArea()
     )
+
   }
 }
 

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -135,8 +135,11 @@ private struct OnboardingBodyView: View {
       }
       .padding(.horizontal, 20)
     }
-    .onChange(of: incomeAmount) { oldValue, newValue in
+    .onChange(of: incomeAmount) { _, _ in
       incomeAmount = (incomeAmount.numberFormat ?? 0).decimal
+    }
+    .onChange(of: showDayPicker) {
+      if $1 { isFocused = false }
     }
   }
 }

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -62,7 +62,7 @@ struct Onboarding3View: View {
 
 private struct OnboardingHeaderView: View {
   var body: some View {
-    VStack(spacing: 28) {
+    VStack(spacing: 30) {
       OnboardingNavigationHeaderView(onboardingPage: .first)
       
       VStack(alignment: .leading, spacing: 6) {
@@ -117,7 +117,7 @@ private struct OnboardingBodyView: View {
           title: "금액",
           text: $incomeAmount
         )
-        .padding(.top, 14)
+        .padding(.top, 16)
         .keyboardType(.numberPad)
       }
       .padding(.horizontal, 20)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -109,7 +109,7 @@ private struct OnboardingBodyView: View {
       .padding(.top, 34)
       
       VStack(alignment: .leading, spacing: 0) {
-        Text("한 달의 수입금은 얼마인가요?")
+        Text("한 달의 총 수입 금액은 얼마인가요?")
           .font(.pretendardMedium_20)
           .foregroundStyle(Color.textBlack)
         

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -47,29 +47,27 @@ struct Onboarding3View: View {
           self.isPresented = true
         }
       }
-      .contentShape(Rectangle())
-      .onTapGesture {
-        UIApplication.shared.endEditing()
-      }
-      .onChange(of: incomeDay, { _, _ in
-        viewModel.send(.updateFixedIncomeDay(incomeDay))
-      })
-      .navigationDestination(isPresented: $isPresented) {
-        Onboarding4View(viewModel: viewModel)
-          .navigationBarBackButtonHidden()
-      }
       
       if isFocused {
         NumberKeypadView(amount: $incomeAmount) {
           self.isFocused = false
-          if !incomeAmount.isEmpty {
-            viewModel.send(.updateFixedIncomeAmount(
-              incomeAmount.numberFormat ?? 0
-            ))
-            self.isEnabled = true
-          }
         }
       }
+    }
+    .onChange(of: incomeDay, { _, _ in
+      viewModel.send(.updateFixedIncomeDay(incomeDay))
+    })
+    .onChange(of: incomeAmount, { _, _ in
+      if !incomeAmount.isEmpty {
+        viewModel.send(.updateFixedIncomeAmount(
+          incomeAmount.numberFormat ?? 0
+        ))
+        self.isEnabled = true
+      }
+    })
+    .navigationDestination(isPresented: $isPresented) {
+      Onboarding4View(viewModel: viewModel)
+        .navigationBarBackButtonHidden()
     }
   }
 }

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding3View.swift
@@ -13,6 +13,8 @@ struct Onboarding3View: View {
   
   @State private var isPresented: Bool = false
   @State private var isEnabled: Bool
+  @State private var isFocused: Bool = false
+  @State private var showDayPicker: Bool = false
   @State private var incomeDay: Int
   @State private var incomeAmount: String
   
@@ -25,37 +27,49 @@ struct Onboarding3View: View {
   }
   
   var body: some View {
-    VStack(spacing: 0) {
-      OnboardingHeaderView()
-      
-      OnboardingBodyView(
-        incomeDay: $incomeDay,
-        incomeAmount: $incomeAmount
-      )
-      
-      Spacer()
-      
-      MainColorBottomButton(
-        title: "다음으로",
-        isEnabled: $isEnabled
-      ) {
-        self.isPresented = true
+    ZStack(alignment: .bottom) {
+      VStack(spacing: 0) {
+        OnboardingHeaderView()
+        
+        OnboardingBodyView(
+          incomeDay: $incomeDay,
+          incomeAmount: $incomeAmount,
+          isFocused: $isFocused,
+          showDayPicker: $showDayPicker
+        )
+        
+        Spacer()
+        
+        MainColorBottomButton(
+          title: "다음으로",
+          isEnabled: $isEnabled
+        ) {
+          self.isPresented = true
+        }
       }
-    }
-    .contentShape(Rectangle())
-    .onTapGesture {
-      UIApplication.shared.endEditing()
-    }
-    .onChange(of: incomeAmount, { _, _ in
-      viewModel.send(.updateFixedIncomeAmount(incomeAmount.numberFormat ?? 0))
-      self.isEnabled = true
-    })
-    .onChange(of: incomeDay, { _, _ in
-      viewModel.send(.updateFixedIncomeDay(incomeDay))
-    })
-    .navigationDestination(isPresented: $isPresented) {
-      Onboarding4View(viewModel: viewModel)
-        .navigationBarBackButtonHidden()
+      .contentShape(Rectangle())
+      .onTapGesture {
+        UIApplication.shared.endEditing()
+      }
+      .onChange(of: incomeDay, { _, _ in
+        viewModel.send(.updateFixedIncomeDay(incomeDay))
+      })
+      .navigationDestination(isPresented: $isPresented) {
+        Onboarding4View(viewModel: viewModel)
+          .navigationBarBackButtonHidden()
+      }
+      
+      if isFocused {
+        NumberKeypadView(amount: $incomeAmount) {
+          self.isFocused = false
+          if !incomeAmount.isEmpty {
+            viewModel.send(.updateFixedIncomeAmount(
+              incomeAmount.numberFormat ?? 0
+            ))
+            self.isEnabled = true
+          }
+        }
+      }
     }
   }
 }
@@ -82,23 +96,17 @@ private struct OnboardingHeaderView: View {
 }
 
 private struct OnboardingBodyView: View {
-  
-  @Binding private var incomeDay: Int
-  @Binding private var incomeAmount: String
-  
-  init(
-    incomeDay: Binding<Int>,
-    incomeAmount: Binding<String>
-  ) {
-    self._incomeDay = incomeDay
-    self._incomeAmount = incomeAmount
-  }
+  @Binding var incomeDay: Int
+  @Binding var incomeAmount: String
+  @Binding var isFocused: Bool
+  @Binding var showDayPicker: Bool
   
   var body: some View {
     VStack(spacing: 30) {
       DayPickerView(
         title: "주요 수입일은 언제인가요?",
         titleFont: .onboarding,
+        showDayPicker: $showDayPicker,
         selectedDay: $incomeDay
       )
       .padding(.top, 34)
@@ -113,15 +121,19 @@ private struct OnboardingBodyView: View {
           .foregroundStyle(Color.textBlack30)
           .padding(.top, 6)
         
-        FloatingTitleTextField(
+        FloatingTitleNumberField(
           title: "금액",
-          text: $incomeAmount
+          textSize: .medium,
+          text: $incomeAmount,
+          isFocused: $isFocused
         )
+        .onTapGesture {
+          isFocused = true
+          showDayPicker = false
+        }
         .padding(.top, 16)
-        .keyboardType(.numberPad)
       }
       .padding(.horizontal, 20)
-      
     }
     .onChange(of: incomeAmount) { oldValue, newValue in
       incomeAmount = (incomeAmount.numberFormat ?? 0).decimal

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
@@ -11,17 +11,28 @@ import SwiftUI
 struct Onboarding4View: View {
   private var viewModel: OnboardingViewModel
   
-  @State private var previousExpenseAmount: String
-  
+  @State private var currentBalanceAmount: String
   @State private var isEnabled: Bool
-  @State private var isFocused: Bool = false
+  @State private var isFocused: Bool = true
   @State private var isPresented: Bool = false
   
   init(viewModel: OnboardingViewModel) {
     self.viewModel = viewModel
-    self._previousExpenseAmount = .init(initialValue: viewModel.state.previousExpense?.decimal ?? "")
     
-    self._isEnabled = .init(initialValue: viewModel.state.previousExpense == nil ? false : true)
+    if let currentBalance = viewModel.state.currentBalance {
+      self._currentBalanceAmount = .init(
+        initialValue: currentBalance.decimalWithWon
+      )
+    } else {
+      self._currentBalanceAmount = .init(
+        initialValue: viewModel.state.incomeAmount?.decimalWithWon ?? ""
+      )
+    }
+    
+    self._isEnabled = .init(
+      initialValue: viewModel.state.currentBalance == nil
+      ? false : true
+    )
   }
   
   var body: some View {
@@ -33,7 +44,7 @@ struct Onboarding4View: View {
         
         OnboardingBodyView(
           startDate: viewModel.state.incomeStartDate,
-          expenseAmount: $previousExpenseAmount,
+          currentBalance: $currentBalanceAmount,
           isFocused: $isFocused
         )
         
@@ -46,14 +57,12 @@ struct Onboarding4View: View {
       }
       
       if isFocused {
-        NumberKeypadView(amount: $previousExpenseAmount) {
+        NumberKeypadView(amount: $currentBalanceAmount) {
           self.isFocused = false
-          if !previousExpenseAmount.isEmpty {
-            
-            viewModel.send(.updatePreviousExpense(
-              previousExpenseAmount.numberFormat ?? 0
+          if !currentBalanceAmount.isEmpty {
+            viewModel.send(.updateCurrentBalance(
+              currentBalanceAmount.numberFormat ?? 0
             ))
-            
             self.isEnabled = true
           }
         }
@@ -99,10 +108,9 @@ private struct OnboardingHeaderView: View {
 }
 
 private struct OnboardingBodyView: View {
-  
-  
   let startDate: Date
-  @Binding var expenseAmount: String
+  
+  @Binding var currentBalance: String
   @Binding var isFocused: Bool
   
   private var dateString: String {
@@ -120,7 +128,7 @@ private struct OnboardingBodyView: View {
       FloatingTitleNumberField(
         title: "금액",
         textSize: .medium,
-        text: $expenseAmount,
+        text: $currentBalance,
         isFocused: $isFocused
       )
       .onTapGesture {
@@ -128,7 +136,6 @@ private struct OnboardingBodyView: View {
       }
       .padding(.horizontal, 16)
       .padding(.top, 16)
-      
       
       VStack(alignment: .leading, spacing: 2) {
         Text("*신용카드 사용 등의 이유로 잔액 파악이 어렵다면")
@@ -139,7 +146,6 @@ private struct OnboardingBodyView: View {
       .font(.pretendardMedium_12)
       .padding(.top, 10)
       .padding(.horizontal, 20)
-      
     }
     .padding(.top, 30)
     .frame(maxHeight: .infinity, alignment: .top)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
@@ -68,6 +68,9 @@ struct Onboarding4View: View {
         }
       }
     }
+    .onAppear {
+      viewModel.send(.onAppearOnboardingStep3)
+    }
     .navigationDestination(isPresented: $isPresented) {
       Onboarding5View(viewModel: viewModel)
         .navigationBarBackButtonHidden()

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding4View.swift
@@ -110,35 +110,36 @@ private struct OnboardingBodyView: View {
   }
   
   var body: some View {
-    VStack(spacing: 14) {
-      VStack(alignment: .leading, spacing: 6) {
-        Text("\(dateString)부터 오늘까지")
-        Text("얼마를 사용하셨나요?")
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .font(.pretendardMedium_20)
-      .foregroundStyle(Color.textBlack)
-      .padding(.horizontal, 20)
+    VStack(spacing: 0) {
+      Text("현재 잔액은 얼마인가요?")
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .font(.pretendardMedium_20)
+        .foregroundStyle(Color.textBlack)
+        .padding(.horizontal, 20)
       
-      VStack(alignment: .leading, spacing: 0) {
-        
-        FloatingTitleNumberField(
-          title: "금액",
-          textSize: .medium,
-          text: $expenseAmount,
-          isFocused: $isFocused
-        )
-        .onTapGesture {
-          isFocused = true
-        }
-        
-        Text("*계산이 어렵다면 수입금에서 잔액을 빼서 계산하는 방법도 있어요!")
-          .foregroundStyle(Color.textBlack30)
-          .font(.pretendardMedium_12)
-          .padding(.top, 6)
-          .padding(.horizontal, 4)
+      FloatingTitleNumberField(
+        title: "금액",
+        textSize: .medium,
+        text: $expenseAmount,
+        isFocused: $isFocused
+      )
+      .onTapGesture {
+        isFocused = true
       }
       .padding(.horizontal, 16)
+      .padding(.top, 16)
+      
+      
+      VStack(alignment: .leading, spacing: 2) {
+        Text("*신용카드 사용 등의 이유로 잔액 파악이 어렵다면")
+        Text("수입금에서 지출 금액을 빼서 계산하는 방법도 있어요!")
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .foregroundStyle(Color.textBlack30)
+      .font(.pretendardMedium_12)
+      .padding(.top, 10)
+      .padding(.horizontal, 20)
+      
     }
     .padding(.top, 30)
     .frame(maxHeight: .infinity, alignment: .top)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
@@ -32,7 +32,7 @@ struct Onboarding5View: View {
         viewModel: viewModel,
         fixedExpenses: $fixedExpenses
       )
-        .padding(.top, 30)
+        .padding(.top, 32)
       
       
       Spacer()
@@ -90,7 +90,6 @@ private struct OnboardingHeaderView: View {
 }
 
 private struct OnboardingBodyView: View {
-  
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
       Text("매달 고정으로 나가는 지출 목록을")
@@ -123,7 +122,7 @@ private struct FixedExpensesListView: View {
   var body: some View {
     VStack(spacing: 0) {
       listHeaderView
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 22)
         .foregroundStyle(Color.textBlack)
       
       if fixedExpenses.isEmpty {

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
@@ -24,7 +24,7 @@ struct Onboarding5View: View {
     VStack(spacing: 0) {
       OnboardingHeaderView(harubee: viewModel.state.averageHarubee)
       
-      OnboardingBodyView()
+      onboardingBodyTitleView
         .padding(.top, 30)
         .padding(.horizontal, 20)
       
@@ -48,6 +48,16 @@ struct Onboarding5View: View {
       Onboarding6View(viewModel: viewModel)
         .navigationBarBackButtonHidden()
     }
+  }
+  
+  private var onboardingBodyTitleView: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("매달 고정으로 나가는 지출 목록을")
+      Text("입력해주세요 (예: 월세, 구독비, 저축)")
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .font(.pretendardMedium_20)
+    .foregroundStyle(Color.textBlack)
   }
 }
 
@@ -86,18 +96,6 @@ private struct OnboardingHeaderView: View {
     .background(
       Rectangle().fill(Color.main).ignoresSafeArea()
     )
-  }
-}
-
-private struct OnboardingBodyView: View {
-  var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text("매달 고정으로 나가는 지출 목록을")
-      Text("입력해주세요 (예: 월세, 구독비, 저축)")
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .font(.pretendardMedium_20)
-    .foregroundStyle(Color.textBlack)
   }
 }
 

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
@@ -222,7 +222,7 @@ private struct FixedExpensesListView: View {
     ) { day, name, price in
       saveFixedExpense(day: day, name: name, price: price)
     }
-    .presentationDetents([.fraction(0.8)])
+    .presentationDetents([.large])
     .presentationCornerRadius(20)
   }
   

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
@@ -42,7 +42,7 @@ struct Onboarding6View: View {
           
           UserInfoView(
             incomeAmount: viewModel.state.incomeAmount ?? 0,
-            previousExpense: viewModel.state.previousExpense ?? 0,
+            currentBalance: viewModel.state.currentBalance ?? 0,
             fixedExpenses: viewModel.state.fixedExpenses,
             startDate: viewModel.state.incomeStartDate,
             endDate: viewModel.state.incomeEndDate
@@ -118,20 +118,20 @@ private struct CurrentHarubeeView: View {
 private struct UserInfoView: View {
   
   private let incomeAmount: Int
-  private let previousExpense: Int
+  private let currentBalance: Int
   private let fixedExpenses: [TransactionItem]
   private let startDate: Date
   private let endDate: Date
   
   init(
     incomeAmount: Int,
-    previousExpense: Int,
+    currentBalance: Int,
     fixedExpenses: [TransactionItem],
     startDate: Date,
     endDate: Date
   ) {
     self.incomeAmount = incomeAmount
-    self.previousExpense = previousExpense
+    self.currentBalance = currentBalance
     self.fixedExpenses = fixedExpenses
     self.startDate = startDate
     self.endDate = endDate
@@ -147,7 +147,7 @@ private struct UserInfoView: View {
       
       UserInfoItemView(
         title: "현재 잔액",
-        content: "- \(previousExpense.decimalWithWon)"
+        content: currentBalance.decimalWithWon
       )
       
       UserInfoItemView(

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
@@ -99,7 +99,7 @@ private struct CurrentHarubeeView: View {
       }
       .padding(.horizontal, 4)
       
-      Text("(잔액 - 미래 고정지출) ÷ 다음 주요 수입일까지 남은 일수")
+      Text("(잔액 - 예정된 고정지출) ÷ 다음 주요 수입일까지 남은 일수")
         .font(.pretendardSemibold_14)
         .foregroundStyle(Color.whiteDefault)
         .frame(maxWidth: .infinity)
@@ -140,23 +140,24 @@ private struct UserInfoView: View {
   var body: some View {
     VStack(spacing: 12) {
       UserInfoItemView(
-        title: "한 달 수입금",
-        content: incomeAmount.decimalWithWon
+        title: "수입금 중",
+        content: incomeAmount.decimalWithWon,
+        contentColor: .whiteDeep50
       )
       
       UserInfoItemView(
-        title: "수입일(\(startDate.formattedDateToString(.monthDay_kr))) 이후 지출한 금액",
+        title: "현재 잔액",
         content: "- \(previousExpense.decimalWithWon)"
       )
       
       UserInfoItemView(
-        title: "고정 지출 (총 \(fixedExpenses.count)건)",
+        title: "고정 지출 (총 \(fixedExpenses.count)건) 중",
         content: "\(fixedExpenses.reduce(0) { $0 + $1.price }.decimalWithWon)",
         contentColor: .whiteDeep50
       )
       
       UserInfoItemView(
-        title: "앞으로 나갈 고정 지출 (총 \(fixedExpenses.filter { $0.date > .now.formattedDate }.count)건)",
+        title: "예정된 고정 지출 (총 \(fixedExpenses.filter { $0.date > .now.formattedDate }.count)건)",
         content: "- \(fixedExpenses.filter { $0.date > .now.formattedDate }.reduce(0) { $0 + $1.price }.decimalWithWon)"
       )
       .padding(.leading, 14)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding6View.swift
@@ -23,7 +23,7 @@ struct Onboarding6View: View {
           .padding(.horizontal, 20)
         
         VStack(spacing: 0) {
-          TitleView()
+          titleView
             .padding(.top, 22)
             .padding(.horizontal, 4)
           
@@ -62,10 +62,8 @@ struct Onboarding6View: View {
       
     }
   }
-}
-
-private struct TitleView: View {
-  var body: some View {
+  
+  private var titleView: some View {
     VStack(alignment: .leading, spacing: 0) {
       Text("모든 단계가")
       Text("끝났어요!")

--- a/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
@@ -116,7 +116,7 @@ private struct FixedExpensesListView: View {
           price: price
         )
       }
-      .presentationDetents([.fraction(0.8)])
+      .presentationDetents([.large])
       .presentationCornerRadius(20)
     }
     .onChange(of: selectedItem) { _, _ in }

--- a/Harubee/Sources/Presentation/Setting/Views/FixedIncomeView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedIncomeView.swift
@@ -139,7 +139,7 @@ private struct FixedIncomeBodyView: View {
       )
       
       HStack(spacing: 0) {
-        Text("금액")
+        Text("총 수입 금액")
           .font(.pretendardMedium_18)
         
         Spacer()

--- a/Harubee/Sources/Presentation/Setting/Views/FixedIncomeView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedIncomeView.swift
@@ -125,6 +125,7 @@ private struct FixedIncomeBodyView: View {
   let settingViewModel: SettingViewModel
   
   @State private var showingSheet: Bool = false
+  @State private var showDayPicker: Bool = false
   @Binding var selectedDay: Int
   @Binding var fixedIncomeAmount: Int
   
@@ -133,6 +134,7 @@ private struct FixedIncomeBodyView: View {
       DayPickerView(
         title: "주요 고정수입 날짜",
         titleFont: .view,
+        showDayPicker: $showDayPicker,
         selectedDay: $selectedDay
       )
       


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
- 온보딩의 자잘한 UI 수정사항을 반영했습니다.
- 온보딩에서 이전 지출액이 아닌 잔액으로 하루비를 계산하도록 수정했습니다.

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #172 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208826541867471

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|온보딩 잔액으로 수정|<img src = "https://github.com/user-attachments/assets/1792c456-7eb7-4073-808a-6d88583c3660" width ="250">|

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->
### 1) DayPickerView 변경 사항
원래 DayPickerView에서 keyboardObserver로 키보드를 감지하고 DayPicker의 활성화 여부를 관리해주었는데,
`showDayPicker` 변수를 Binding으로 선언해 DayPickerView를 사용하는 뷰에서 `showDayPicker`를 넘겨주고
NumberKeypadView가 활성화되는 경우 (`isFocused = true`) `showDayPicker = false`로 변경하도록 했습니다.
(아래 코드 참고)

```
DayPickerView(
  title: "주요 수입일은 언제인가요?",
  titleFont: .onboarding,
  showDayPicker: $showDayPicker,
  selectedDay: $incomeDay
)
.padding(.top, 34)


FloatingTitleNumberField(
  title: "금액",
  textSize: .medium,
  text: $incomeAmount,
  isFocused: $isFocused
)
.onTapGesture {
  isFocused = true
  showDayPicker = false
}
.padding(.top, 16)
```

### 2) 고정 지출 시트 크기 변경 사항 
고정 지출 입력 화면에서 고정 지출 이름과 금액이 서로 다른 입력 키보드를 사용하면서 다음과 같은 문제가 발생했습니다. 

<img src = "https://github.com/user-attachments/assets/4ccf9e6d-6a0c-4a12-96c7-ed5d250923ff" width ="250"> 

`.ignoreSafeArea(.keyboard)` 와 같은 방법으로 해결하려고 해보았지만 해결이 되지 않고 같은 문제가 발생해서 임시로 고정 지출 추가 및 수정 시트의 크기를 `.large`로 변경하게 되었습니다.

<img src = "https://github.com/user-attachments/assets/c8520c76-bc26-49f4-ba01-0c9f33b7c790" width ="250">