### PR TITLE
[Hotfix] 여러 버그 수정 및 코드 리펙토링

### DIFF
--- a/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
+++ b/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
@@ -61,7 +61,9 @@ extension SalaryBudgetDTO {
       startDate: self.startDate,
       endDate: self.endDate,
       fixedIncome: self.fixedIncome,
-      fixedExpenses: self.fixedExpenses.map { $0.toEntity() },
+      fixedExpenses: self.fixedExpenses
+        .map { $0.toEntity() }
+        .sorted { $0.date < $1.date },
       balance: self.balance,
       defaultHarubee: self.defaultHarubee,
       dailyBudgets: self.dailyBudgets

--- a/Harubee/Sources/Helper/Extensions/Date+.swift
+++ b/Harubee/Sources/Helper/Extensions/Date+.swift
@@ -70,6 +70,8 @@ extension Date {
     return formatter.string(from: self)
   }
   
+  
+  // TODO: 수정 필요
   /// 수입일을 기준으로 이번 월급 기간을 계산해줍니다.
   /// - Parameter incomeDay: 수입일
   /// - Returns: 이번 월급 기간의 시작 및 종료 날짜

--- a/Harubee/Sources/Helper/Extensions/Int+.swift
+++ b/Harubee/Sources/Helper/Extensions/Int+.swift
@@ -45,20 +45,25 @@ extension Int {
   func convertDateBetweenStartAndEnd(start: Date, end: Date) -> Date {
     let calendar = Calendar.current
     
-    var startDateComponents = calendar.dateComponents([.year, .month, .day], from: start)
-    let endDateComponents = calendar.dateComponents([.year, .month, .day], from: end)
+    var current = start
     
-    while startDateComponents != endDateComponents {
-      let day = startDateComponents.day!
-      if day == self {
-        return calendar.date(from: startDateComponents)!
-      }
-      startDateComponents.day! += 1
+    while current <= end {
+      let day = current.day
       
-      let start = calendar.date(from: startDateComponents)!
-      startDateComponents = calendar.dateComponents([.year, .month, .day], from: start)
+      if day == self { return current }
+      
+      current.addTimeInterval(86400)
     }
     
-    return calendar.date(from: endDateComponents)!
+    // 해당 날짜가 기간 사이에 존재하지 않는 경우는 시작 날짜의 달의 마지막 날을 리턴
+    let dateComponents = calendar.dateComponents([.year, .month], from: start)
+    let date = calendar.date(from: dateComponents)!
+    let lastDay = calendar.range(of: .day, in: .month, for: date)!.last!
+    
+    return Date.create(
+      year: dateComponents.year!,
+      month: dateComponents.month!,
+      day: lastDay
+    )
   }
 }

--- a/Harubee/Sources/Presentation/Common/Components/MainColorBottomButton.swift
+++ b/Harubee/Sources/Presentation/Common/Components/MainColorBottomButton.swift
@@ -13,15 +13,26 @@ struct MainColorBottomButton: View {
   @Binding private var isEnabled: Bool
   
   private let title: String
+  private let isReverseColor: Bool
   private let action: () -> Void
+  
+  private var foregroundColor: Color {
+    !isReverseColor ? .whiteDefault : .main
+  }
+  
+  private var backgroundColor: Color {
+    !isReverseColor ? .main : .whiteDefault
+  }
   
   init(
     title: String,
     isEnabled: Binding<Bool> = .constant(true),
+    isReverseColor: Bool = false,
     action: @escaping () -> Void
   ) {
     self.title = title
     self._isEnabled = isEnabled
+    self.isReverseColor = isReverseColor
     self.action = action
   }
   
@@ -29,11 +40,19 @@ struct MainColorBottomButton: View {
     HStack {
       Text(title)
         .font(.pretendardSemibold_18)
-        .foregroundStyle(isEnabled ? Color.whiteDefault : Color.whiteDeep)
+        .foregroundStyle(
+          isEnabled
+          ? foregroundColor
+          : Color.whiteDeep
+        )
         .padding(.vertical, 20)
     }
     .frame(maxWidth: .infinity)
-    .background(isEnabled ? Color.main : Color.main30)
+    .background(
+      isEnabled
+      ? backgroundColor
+      : Color.main30
+    )
     .clipShape(RoundedRectangle(cornerRadius: 10))
     .tapFeedback(haptic: .none) {
       action()

--- a/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -17,8 +17,8 @@ final class OnboardingViewModel {
     var fixedExpenses: [TransactionItem] = [] // 고정 지출 내역
     var averageHarubee: Int = 0 // 평균 하루비
     
-    var incomeStartDate: Date = .now
-    var incomeEndDate: Date = .now
+    var incomeStartDate: Date
+    var incomeEndDate: Date
   }
   
   enum Action {
@@ -32,10 +32,13 @@ final class OnboardingViewModel {
   
   private let budgetUseCase: BudgetUseCase
   
-  private(set) var state: State = .init()
+  private(set) var state: State
   
   init(budgetUseCase: BudgetUseCase) {
     self.budgetUseCase = budgetUseCase
+    
+    let (start, end) = Date.calculateStartAndEndDate(from: 1)
+    self.state = .init(incomeStartDate: start, incomeEndDate: end)
   }
   
   func send(_ action: Action) {

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding1View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding1View.swift
@@ -33,20 +33,11 @@ struct Onboarding1View: View {
       }
       .frame(maxHeight: .infinity)
       .padding(.bottom, 100)
-      //        Text(isVisible ? "화면을 터치해주세요" : " ")
-      //          .padding(.bottom, 50)
-      //          .font(.pretendardSemibold_16)
-      //          .foregroundStyle(.whiteDefault)
       
-      
-      if isVisible {
-        MainColorBottomButton(
-          title: "다음으로",
-          isReverseColor: true
-        ) {
-          isPresented = true
-        }
-      }
+      Text(isVisible ? "화면을 터치해주세요" : " ")
+        .padding(.bottom, 50)
+        .font(.pretendardSemibold_16)
+        .foregroundStyle(.whiteDefault)
     }
     .onAppear {
       DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
@@ -55,9 +46,9 @@ struct Onboarding1View: View {
         }
       }
     }
-//    .onTapGesture {
-//      self.isPresented = isVisible
-//    }
+    .onTapGesture {
+      self.isPresented = isVisible
+    }
     .navigationDestination(isPresented: $isPresented) {
       Onboarding2View(viewModel: viewModel)
         .navigationBarBackButtonHidden()

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding1View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding1View.swift
@@ -11,35 +11,53 @@ import Lottie
 
 struct Onboarding1View: View {
   @State private var viewModel: OnboardingViewModel
-  @State var isPresented: Bool = false
+  @State private var isVisible: Bool = false
+  @State private var isPresented: Bool = false
   
   init(viewModel: OnboardingViewModel) {
     self.viewModel = viewModel
   }
   
   var body: some View {
-    ZStack {
+    ZStack(alignment: .bottom) {
       Color.main.ignoresSafeArea()
-      VStack(spacing: 0) {
-        ZStack(alignment: .bottom) {
-          LottieView(animation: .onboarding)
-            .playing(loopMode: .loop)
-            .frame(height: 146)
-          Text("쉽고 빠른 지출 계획의 시작")
-            .font(.pretendardSemibold_20)
-            .foregroundStyle(Color.whiteDefault)
-            .padding(.bottom, 7)
-        }
-        .padding(.top, UIScreen.main.bounds.height * 0.28)
-        // 피그마에서 Lottie 위로 padding 244, 244 / 852 * 100 = 28.~~~
-        
-        Spacer()
-        
-        MainColorBottomButton(title: "시작하기") {
-          self.isPresented = true
+      
+      VStack {
+        LottieView(animation: .onboarding)
+          .playing(loopMode: .loop)
+          .frame(height: 146)
+        Text("쉽고 빠른 지출 계획의 시작")
+          .font(.pretendardSemibold_20)
+          .foregroundStyle(Color.whiteDefault)
+          .offset(y: -30)
+      }
+      .frame(maxHeight: .infinity)
+      .padding(.bottom, 100)
+      //        Text(isVisible ? "화면을 터치해주세요" : " ")
+      //          .padding(.bottom, 50)
+      //          .font(.pretendardSemibold_16)
+      //          .foregroundStyle(.whiteDefault)
+      
+      
+      if isVisible {
+        MainColorBottomButton(
+          title: "다음으로",
+          isReverseColor: true
+        ) {
+          isPresented = true
         }
       }
     }
+    .onAppear {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        withAnimation {
+          self.isVisible = true
+        }
+      }
+    }
+//    .onTapGesture {
+//      self.isPresented = isVisible
+//    }
     .navigationDestination(isPresented: $isPresented) {
       Onboarding2View(viewModel: viewModel)
         .navigationBarBackButtonHidden()

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding2View.swift
@@ -31,23 +31,11 @@ struct Onboarding2View: View {
           .padding(.horizontal, 16)
         Spacer()
         
-        Button {
-          self.isPresented = true
-        } label: {
-          HStack {
-            Text("다음으로")
-              .font(.pretendardSemibold_18)
-              .foregroundStyle(Color.main)
-              .padding(.vertical, 20)
+        MainColorBottomButton(
+          title: "다음으로",
+          isReverseColor: true) {
+            isPresented = true
           }
-          .frame(maxWidth: .infinity)
-          .background(Color.whiteDefault)
-        }
-        .clipShape(
-          RoundedRectangle(cornerRadius: 10)
-        )
-        .padding(.bottom, 9)
-        .padding(.horizontal, 16)
       }
       .frame(maxHeight: .infinity, alignment: .top)
       .padding(.top, 76)

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
@@ -28,7 +28,7 @@ struct Onboarding5View: View {
         .padding(.top, 30)
         .padding(.horizontal, 20)
       
-      FixedExpensesListView(
+      FixedExpenseListView(
         viewModel: viewModel,
         fixedExpenses: $fixedExpenses
       )
@@ -99,23 +99,13 @@ private struct OnboardingHeaderView: View {
   }
 }
 
-private struct FixedExpensesListView: View {
-  private var viewModel: OnboardingViewModel
+private struct FixedExpenseListView: View {
+  let viewModel: OnboardingViewModel
   
-  @State private var isPresented: Bool = false
-  @Binding private var fixedExpenses: [TransactionItem]
-  
-  @State private var manageMode: Mode
+  @State private var manageMode: Mode = .add
   @State private var selectedItem: TransactionItem?
-  
-  init(
-    viewModel: OnboardingViewModel,
-    fixedExpenses: Binding<[TransactionItem]>
-  ) {
-    self.viewModel = viewModel
-    self._fixedExpenses = fixedExpenses
-    self._manageMode = State(initialValue: .add)
-  }
+  @State private var isPresented: Bool = false
+  @Binding var fixedExpenses: [TransactionItem]
   
   var body: some View {
     VStack(spacing: 0) {
@@ -142,7 +132,20 @@ private struct FixedExpensesListView: View {
       }
     }
     .sheet(isPresented: $isPresented) {
-      fixedExpenseSheet()
+      FixedExpenseManageView(
+        mode: self.manageMode,
+        selectedDay: selectedItem?.date.day ?? 1,
+        fixedExpenseName: selectedItem?.name ?? "",
+        fixedExpenseAmount: selectedItem?.price.decimal ?? ""
+      ) { day, name, price in
+        saveFixedExpense(
+          day: day,
+          name: name,
+          price: price
+        )
+      }
+      .presentationDetents([.large])
+      .presentationCornerRadius(20)
     }
     .onChange(of: selectedItem) { _, _ in }
     .onChange(of: fixedExpenses) { _, _ in
@@ -178,10 +181,6 @@ private struct FixedExpensesListView: View {
       .padding(.top, 150)
   }
   
-  private func removeList(at offsets: IndexSet) {
-    fixedExpenses.remove(atOffsets: offsets)
-  }
-  
   private func fixedExpensesRow(
     for item: TransactionItem
   ) -> some View {
@@ -211,19 +210,6 @@ private struct FixedExpensesListView: View {
     .contentShape(Rectangle())
   }
   
-  private func fixedExpenseSheet() -> some View {
-    FixedExpenseManageView(
-      mode: manageMode,
-      selectedDay: selectedItem?.date.day ?? 1,
-      fixedExpenseName: selectedItem?.name ?? "",
-      fixedExpenseAmount: selectedItem?.price.decimal ?? ""
-    ) { day, name, price in
-      saveFixedExpense(day: day, name: name, price: price)
-    }
-    .presentationDetents([.large])
-    .presentationCornerRadius(20)
-  }
-  
   private func saveFixedExpense(
     day: Int,
     name: String,
@@ -234,12 +220,13 @@ private struct FixedExpensesListView: View {
       end: viewModel.state.incomeEndDate
     )
     
-    if let item = selectedItem {
-      if let index = fixedExpenses.firstIndex(where: { $0.id == item.id }) {
-        fixedExpenses[index].date = date
-        fixedExpenses[index].name = name
-        fixedExpenses[index].price = price.numberFormat ?? 0
-      }
+    if let item = selectedItem,
+       let index = fixedExpenses.firstIndex(where: {
+         $0.id == item.id
+       }) {
+      fixedExpenses[index].date = date
+      fixedExpenses[index].name = name
+      fixedExpenses[index].price = price.numberFormat ?? 0
     } else {
       fixedExpenses.append(.init(
         date: date,
@@ -247,6 +234,10 @@ private struct FixedExpensesListView: View {
         price: price.numberFormat ?? 0
       ))
     }
+  }
+  
+  private func removeList(at offsets: IndexSet) {
+    fixedExpenses.remove(atOffsets: offsets)
   }
 }
 

--- a/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
@@ -28,7 +28,7 @@ struct FixedExpenseView: View {
           fixedExpenses: salaryBudget.fixedExpenses
         )
         
-        FixedExpensesListView(
+        FixedExpenseListView(
           settingViewModel: settingViewModel,
           fixedExpenses: .init(
             get: {
@@ -70,7 +70,7 @@ private struct FixedExpenseHeaderView: View {
   }
 }
 
-private struct FixedExpensesListView: View {
+private struct FixedExpenseListView: View {
   let settingViewModel: SettingViewModel
   
   @State private var manageMode: Mode = .add
@@ -154,10 +154,6 @@ private struct FixedExpensesListView: View {
       .padding(.top, 150)
   }
   
-  private func removeList(at offsets: IndexSet) {
-    fixedExpenses.remove(atOffsets: offsets)
-  }
-  
   private func fixedExpensesRow(
     for item: TransactionItem
   ) -> some View {
@@ -197,12 +193,13 @@ private struct FixedExpensesListView: View {
       end: settingViewModel.state.salaryBudget.endDate
     )
     
-    if let item = selectedItem {
-      if let index = fixedExpenses.firstIndex(where: { $0.id == item.id }) {
-        fixedExpenses[index].date = date
-        fixedExpenses[index].name = name
-        fixedExpenses[index].price = price.numberFormat ?? 0
-      }
+    if let item = selectedItem,
+       let index = fixedExpenses.firstIndex(where: {
+         $0.id == item.id
+       }) {
+      fixedExpenses[index].date = date
+      fixedExpenses[index].name = name
+      fixedExpenses[index].price = price.numberFormat ?? 0
     } else {
       fixedExpenses.append(.init(
         date: date,
@@ -210,6 +207,10 @@ private struct FixedExpensesListView: View {
         price: price.numberFormat ?? 0
       ))
     }
+  }
+  
+  private func removeList(at offsets: IndexSet) {
+    fixedExpenses.remove(atOffsets: offsets)
   }
 }
 

--- a/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
@@ -17,10 +17,6 @@ struct FixedExpenseView: View {
     settingViewModel.state.salaryBudget
   }
   
-  init(settingViewModel: SettingViewModel) {
-    self.settingViewModel = settingViewModel
-  }
-  
   var body: some View {
     ZStack {
       VStack(spacing: 0) {

--- a/Harubee/Sources/Presentation/Setting/Views/SettingView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/SettingView.swift
@@ -9,17 +9,13 @@
 import SwiftUI
 
 struct SettingView: View {
-  @State private var settingViewModel: SettingViewModel
+  @State var settingViewModel: SettingViewModel
   
   @State private var navigateFixedExpense: Bool = false
   @State private var navigateFixedIncome: Bool = false
   
   private var salaryBudget: SalaryBudget? {
     settingViewModel.state.salaryBudget
-  }
-  
-  init(settingViewModel: SettingViewModel) {
-    self.settingViewModel = settingViewModel
   }
   
   var body: some View {

--- a/Harubee/Sources/Presentation/Setting/Views/SettingView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/SettingView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct SettingView: View {
-  let settingViewModel: SettingViewModel
+  @State private var settingViewModel: SettingViewModel
   
   @State private var navigateFixedExpense: Bool = false
   @State private var navigateFixedIncome: Bool = false

--- a/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
+++ b/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
@@ -76,6 +76,7 @@ extension TodayViewModel {
       ) else { return }
       
       // 3. 새로운 시작일과 종료일 계산
+      // TODO: 수정 필요
       let (newStartDate, newEndDate) = calculateNewSalaryBudgetDates(
         referenceStartDay: Calendar.current.component(
           .day,
@@ -87,12 +88,20 @@ extension TodayViewModel {
         )
       )
       
+      let newFixedExpenses = recentSalaryBudget.fixedExpenses.map {
+        let date = $0.date.day.convertDateBetweenStartAndEnd(
+          start: newStartDate,
+          end: newEndDate
+        )
+        return TransactionItem(date: date, name: $0.name, price: $0.price)
+      }
+      
       // 4. 새로운 SalaryBudget 생성
       if let newSalaryBudget = try? budgetUseCase.createSalaryBudget(
         startDate: newStartDate,
         endDate: newEndDate,
         fixedIncome: recentSalaryBudget.fixedIncome,
-        fixedExpenses: recentSalaryBudget.fixedExpenses
+        fixedExpenses: newFixedExpenses
       ) {
         initializeState(salaryBudget: newSalaryBudget)
       }


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [x] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [x] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
[Hotfix]
1. 온보딩 화면에서 수입 날짜를 조작하지 않았을 때 SalaryBudget의 기간이 하루로 설정되는 오류 수정
2. 고정 지출 변경 화면에서 고정 지출 내역을 변경하고 백그라운드로 진입 시 이전 내역으로 돌아가는 오류 수정
3. 고정 지출 내역이 있는 상태에서 다음 기간의 SalaryBudget으로 넘어갈 시(새로 생성될 시) 발생하는 SwiftData 오류 수정

[Refactor]
1. 온보딩 첫 화면 UI 수정
2. FixedExpenseListView 리펙토링
3. SalaryBudgetDTO.toEntity()에서 fixedExpenses 정렬 후 리턴
4. 새로운 기간의 SalaryBudget 생성 로직 수정

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #180 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208855397710074

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

### Hotfix 1. 온보딩 화면에서 수입 날짜를 조작하지 않았을 때 SalaryBudget의 기간이 하루로 설정되는 오류 수정
초기에 `OnboardingViewModel`의 시작, 종료 날짜를 오늘 날짜로 초기화를 시켜놓은 상태에서 `DayPicker`를 조작하지 않고 넘어갔을 때 발생했던 문제였습니다.
따라서, 초기 `OnboardingViewModel`을 초기화할 때 시작, 종료 날짜를 수입날짜 1일을 기준으로 초기화하도록 수정했습니다.
```swift
@Observable
final class OnboardingViewModel {
  struct State {
    ...
    var incomeStartDate: Date
    var incomeEndDate: Date
  }
  ...

  private(set) var state: State
  
  init(budgetUseCase: BudgetUseCase) {
    self.budgetUseCase = budgetUseCase
    
    // 시작 1일, 종료 마지막 날로 초기화
    let (start, end) = Date.calculateStartAndEndDate(from: 1)
    self.state = .init(incomeStartDate: start, incomeEndDate: end)
  }
```

<br>

### Hotfix 2. 고정 지출 변경 화면에서 고정 지출 내역을 변경하고 백그라운드로 진입 시 이전 내역으로 돌아가는 오류 수정
결론부터 말하자면, `SettingView`에서 `SettingViewModel`을 `@State`가 아닌 일반 프로퍼티로 전달받아서 발생한 **View 랜더링 시 인스턴스 초기화 이슈**였습니다.
```swift

struct SettingView: View {
  // 기존 코드
  let settingViewModel: SettingViewModel

  // 변경된 코드
  @State private var settingViewModel: SettingViewModel
}
```

SwiftUI에서 `@State`, `@StateObject`는 뷰가 생성될 때 한번만 초기화하게 됩니다.
따라서 뷰의 정체성이 바뀌는 것이 아닌(뷰가 완전히 새롭게 교체되는 것이 아닌) 단순히 뷰를 다시 그리는 경우에는 동일한 뷰 구조 내에서는 새로운 인스턴스로 생성되지 않고, 기존 인스턴스로 유지됩니다.
이 개념을 가지고 어떠한 과정에서 문제가 발생했는지를 알아보겠습니다.

저희는 `main`에서 다음과 같이 `scenePhase`를 사용했습니다.
```swift
@main
struct HarubeeApp: App {
  @Environment(\.scenePhase) private var scenePhase
  @State private var appRootManager = AppRootManager()
  
  var body: some Scene {
    WindowGroup {
      NavigationStack {
        switch appRootManager.root {
        ...
        case .today:
          TodayView(todayViewModel: DIContainer.shared.makeTodayViewModel())
            .onChange(of: scenePhase) { // 백그라운드 진입 시 위젯 타임라인 reload
              if case ScenePhase.background = $1 {
                WidgetCenter.shared.reloadAllTimelines()
              }
            }
        }
      }
    }
  }
}
```
그리고 저희 앱의 뷰 계층은 다음과 같습니다
```swift
struct HarubeeApp: App {
   ...
   TodayView()
}

struct TodayView: View {
    ...
    SettingView() // todayViewModel에 저장된 salaryBudget을 통해 settingViewModel을 생성해서 넘겨줌
}

struct SettingView: View {
    ...
    FixedExpenseView() // SettingViewModel을 넘겨줌
}
```
그리고 현재 저희 앱 로직이 고정지출 수정 화면에서 고정지출 내역들을 수정하면 `SettingView` 계층(`SettingView` 또는 `FixedExpenseView`)에는 변경된 내역들이 저장되어있지만,
`TodayView`에는 반영이 되지 않은 상태입니다.
(`TodayView`로 이동해야 `onAppear`를 통해 DB에서 변경된 데이터를 가져와 표시함)

이러한 구조에서 `SettingView` 계층 내에서 백그라운드에 진입하게 되면 `main`에서 `.onChange`를 통해 `scenePhase`의 변화를 감지하게 되고, 그에 따라 `TodayView`가 재렌더링 하게 됩니다.
(SwiftUI에서 뷰는 상태(`@State, @Binding, @Environment, ...`)의 변화에 반응하여 뷰를 재렌더링 함)

여기서, `TodayView`에는 아직 변경된 고정지출 내역을 가지고 있지 않기 때문에 `TodayView`에서 `SettingView`로 변경 전 고정 지출 내역을 전달하게 됩니다.
만약, `SettingView`에서 `SettingViewModel`을 `@State`로 저장하고 있었다면, 뷰를 재렌더링하는 과정이기 때문에 새로운 `SettingViewModel`을 생성하지 않았을 겁니다.
하지만, `@State`가 아닌 일반적인 변수로 저장했기 때문에, `SettingViewModel` 인스턴스가 다시 생성되게 되면서 기존 고정지출 내역이 보여지게 된 것입니다.

[**변경 전**]

https://github.com/user-attachments/assets/4c9e92aa-304e-4187-a23f-5754515903cf


[**변경 후**]

https://github.com/user-attachments/assets/5ef5221a-1e92-4dd1-b22e-a0cfa8e149ac

<br>

### Hotfix 3. 고정 지출 내역이 있는 상태에서 다음 기간의 SalaryBudget으로 넘어갈 시(새로 생성될 시) 발생하는 SwiftData 오류 수정
### Refactor 4. 새로운 기간의 SalaryBudget 생성 로직 수정

새로운 기간에 `SalaryBudget`을 생성할 때 기존에 존재하는 `TransactionItem`을 그대로 사용하면서 SwiftData 오류가 발생했습니다.
(`TransactionItem`의 `id`가 unique 특성을 가지고 있는데, 동일한 `id`를 가진 엔티티를 생성하려고 해서 발생한 문제같습니다.)
추가로, 이전 `SalaryBudget`에 저장된 `fixedExpense`로 새로운 기간의 `SalaryBudget`의 `fixedExpense`에 넣어줄 때 새로운 기간에 맞춰 `transactionItem`의 `date` 또한 수정했습니다.
```swift
let newFixedExpenses = recentSalaryBudget.fixedExpenses.map {
  // 시작, 종료 날짜 사이의 date로 변환
  let date = $0.date.day.convertDateBetweenStartAndEnd(
    start: newStartDate,
    end: newEndDate
  )

  // id 및 date 재설정
  return TransactionItem(date: date, name: $0.name, price: $0.price)
}

// 4. 새로운 SalaryBudget 생성
if let newSalaryBudget = try? budgetUseCase.createSalaryBudget(
  startDate: newStartDate,
  endDate: newEndDate,
  fixedIncome: recentSalaryBudget.fixedIncome,
  fixedExpenses: newFixedExpenses
) {
  initializeState(salaryBudget: newSalaryBudget)
}
```