### PR TITLE
[Feature] TransactionItemDTO 모델 수정 (마이그레이션)

### DIFF
--- a/Harubee.xcodeproj/project.pbxproj
+++ b/Harubee.xcodeproj/project.pbxproj
@@ -76,6 +76,8 @@
 				Resources/Images.xcassets,
 				Sources/App/DI/StorageProvider.swift,
 				Sources/Data/DTOs/DailyBudgetDTO.swift,
+				Sources/Data/DTOs/Migration/MigrationPlan.swift,
+				Sources/Data/DTOs/Migration/SchemaVersion.swift,
 				Sources/Data/DTOs/SalaryBudgetDTO.swift,
 				Sources/Data/DTOs/TransactionItemDTO.swift,
 				Sources/Data/Errors/SwiftDataError.swift,

--- a/Harubee/Sources/App/DI/StorageProvider.swift
+++ b/Harubee/Sources/App/DI/StorageProvider.swift
@@ -25,6 +25,7 @@ final class StorageProvider {
     do {
       let container = try ModelContainer(
         for: schema,
+        migrationPlan: MigrationPlan.self,
         configurations: configuration
       )
       return container

--- a/Harubee/Sources/Data/DTOs/DailyBudgetDTO.swift
+++ b/Harubee/Sources/Data/DTOs/DailyBudgetDTO.swift
@@ -9,40 +9,83 @@
 import Foundation
 import SwiftData
 
-@Model
-final class DailyBudgetDTO {
-  @Attribute(.unique) var identifier: String
-  var date: Date
-  var harubee: Int?
-  var memo: [String]
-  var expense: Int?
-  var income: Int?
-  
-  init(
-    id: String,
-    date: Date,
-    harubee: Int? = nil,
-    memo: [String],
-    expense: Int? = nil,
-    income: Int? = nil
-  ) {
-    self.identifier = id
-    self.date = date
-    self.harubee = harubee
-    self.memo = memo
-    self.expense = expense
-    self.income = income
+typealias DailyBudgetDTO = SchemaV2.DailyBudgetDTO
+
+extension SchemaV2 {
+  @Model
+  final class DailyBudgetDTO {
+    @Attribute(.unique) var identifier: String
+    var date: Date
+    var harubee: Int?
+    var memo: [String]
+    var expense: Int?
+    var income: Int?
+    
+    init(
+      id: String,
+      date: Date,
+      harubee: Int? = nil,
+      memo: [String],
+      expense: Int? = nil,
+      income: Int? = nil
+    ) {
+      self.identifier = id
+      self.date = date
+      self.harubee = harubee
+      self.memo = memo
+      self.expense = expense
+      self.income = income
+    }
+    
+    convenience init(_ data: DailyBudget) {
+      self.init(
+        id: data.id,
+        date: data.date,
+        harubee: data.harubee,
+        memo: data.memo,
+        expense: data.expense,
+        income: data.income
+      )
+    }
   }
-  
-  convenience init(_ data: DailyBudget) {
-    self.init(
-      id: data.id,
-      date: data.date,
-      harubee: data.harubee,
-      memo: data.memo,
-      expense: data.expense,
-      income: data.income
-    )
+}
+
+extension SchemaV1 {
+  @Model
+  final class DailyBudgetDTO {
+    @Attribute(.unique) var identifier: String
+    var date: Date
+    var harubee: Int?
+    var memo: [String]
+    var expense: Int?
+    var income: Int?
+    
+    init(
+      id: String,
+      date: Date,
+      harubee: Int? = nil,
+      memo: [String],
+      expense: Int? = nil,
+      income: Int? = nil
+    ) {
+      self.identifier = id
+      self.date = date
+      self.harubee = harubee
+      self.memo = memo
+      self.expense = expense
+      self.income = income
+    }
+    
+    convenience init(_ data: DailyBudget) {
+      self.init(
+        id: data.id,
+        date: data.date,
+        harubee: data.harubee,
+        memo: data.memo,
+        expense: data.expense,
+        income: data.income
+      )
+    }
   }
 }
 

--- a/Harubee/Sources/Data/DTOs/DailyBudgetDTO.swift
+++ b/Harubee/Sources/Data/DTOs/DailyBudgetDTO.swift
@@ -11,6 +11,9 @@ import SwiftData
 
 typealias DailyBudgetDTO = SchemaV2.DailyBudgetDTO
 
+
+// MARK: - SchemaV2
+
 extension SchemaV2 {
   @Model
   final class DailyBudgetDTO {
@@ -50,6 +53,8 @@ extension SchemaV2 {
   }
 }
 
+// MARK: - SchemaV1
+
 extension SchemaV1 {
   @Model
   final class DailyBudgetDTO {
@@ -88,6 +93,9 @@ extension SchemaV1 {
     }
   }
 }
+
+
+// MARK: - toEntity()
 
 extension DailyBudgetDTO {
   func toEntity() -> DailyBudget {

--- a/Harubee/Sources/Data/DTOs/Migration/MigrationPlan.swift
+++ b/Harubee/Sources/Data/DTOs/Migration/MigrationPlan.swift
@@ -1,0 +1,40 @@
+//
+//  MigrationPlan.swift
+//  Harubee
+//
+//  Created by 이정동 on 12/16/24.
+//
+
+import Foundation
+import SwiftData
+
+enum MigrationPlan: SchemaMigrationPlan {
+  static var schemas: [any VersionedSchema.Type] {
+    [
+      SchemaV1.self,
+      SchemaV2.self
+    ]
+  }
+  
+  static var stages: [MigrationStage] {
+    [migrateV1toV2]
+  }
+  
+  static let migrateV1toV2 = MigrationStage.custom(
+    fromVersion: SchemaV1.self,
+    toVersion: SchemaV2.self,
+    willMigrate: nil,
+    didMigrate: { context in
+      let transactionItems = try context.fetch(
+        FetchDescriptor<TransactionItemDTO>()
+      )
+      
+      for item in transactionItems {
+        item.day = item.date.day
+      }
+      
+      try context.save()
+    }
+  )
+}
+

--- a/Harubee/Sources/Data/DTOs/Migration/SchemaVersion.swift
+++ b/Harubee/Sources/Data/DTOs/Migration/SchemaVersion.swift
@@ -1,0 +1,34 @@
+//
+//  SchemaVersion.swift
+//  Harubee
+//
+//  Created by 이정동 on 12/16/24.
+//
+
+import Foundation
+import SwiftData
+
+
+enum SchemaV2: VersionedSchema {
+  static var versionIdentifier: Schema.Version = .init(2, 0, 0)
+  
+  static var models: [any PersistentModel.Type] {
+    [
+      SalaryBudgetDTO.self,
+      DailyBudgetDTO.self,
+      TransactionItemDTO.self
+    ]
+  }
+}
+
+enum SchemaV1: VersionedSchema {
+  static var versionIdentifier: Schema.Version = .init(1, 0, 0)
+  
+  static var models: [any PersistentModel.Type] {
+    [
+      SalaryBudgetDTO.self,
+      DailyBudgetDTO.self,
+      TransactionItemDTO.self
+    ]
+  }
+}

--- a/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
+++ b/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
@@ -9,48 +9,105 @@
 import Foundation
 import SwiftData
 
-@Model
-final class SalaryBudgetDTO {
-  @Attribute(.unique) var identifier: String
-  var startDate: Date
-  var endDate: Date
-  var fixedIncome: Int
-  @Relationship(deleteRule: .cascade) var fixedExpenses: [TransactionItemDTO]
-  var balance: Int
-  var defaultHarubee: Double
-  @Relationship(deleteRule: .cascade) var dailyBudgets: [DailyBudgetDTO]
-  
-  init(
-    id: String,
-    startDate: Date,
-    endDate: Date,
-    fixedIncome: Int,
-    fixedExpenses: [TransactionItem],
-    balance: Int,
-    defaultHarubee: Double,
-    dailyBudgets: [DailyBudget]
-  ) {
-    self.identifier = id
-    self.startDate = startDate
-    self.endDate = endDate
-    self.fixedIncome = fixedIncome
-    self.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
-    self.balance = balance
-    self.defaultHarubee = defaultHarubee
-    self.dailyBudgets = dailyBudgets.map { DailyBudgetDTO($0) }
+typealias SalaryBudgetDTO = SchemaV2.SalaryBudgetDTO
+
+extension SchemaV2 {
+  @Model
+  final class SalaryBudgetDTO {
+    @Attribute(.unique) var identifier: String
+    var startDate: Date
+    var endDate: Date
+    var fixedIncome: Int
+    @Relationship(deleteRule: .cascade) var fixedExpenses: [TransactionItemDTO]
+    var balance: Int
+    var defaultHarubee: Double
+    @Relationship(deleteRule: .cascade) var dailyBudgets: [DailyBudgetDTO]
+    
+    init(
+      id: String,
+      startDate: Date,
+      endDate: Date,
+      fixedIncome: Int,
+      fixedExpenses: [TransactionItem],
+      balance: Int,
+      defaultHarubee: Double,
+      dailyBudgets: [DailyBudget]
+    ) {
+      self.identifier = id
+      self.startDate = startDate
+      self.endDate = endDate
+      self.fixedIncome = fixedIncome
+      self.fixedExpenses = fixedExpenses.map { TransactionItemDTO($0) }
+      self.balance = balance
+      self.defaultHarubee = defaultHarubee
+      self.dailyBudgets = dailyBudgets.map { DailyBudgetDTO($0) }
+    }
+    
+    convenience init(_ data: SalaryBudget) {
+      self.init(
+        id: data.id,
+        startDate: data.startDate,
+        endDate: data.endDate,
+        fixedIncome: data.fixedIncome,
+        fixedExpenses: data.fixedExpenses,
+        balance: data.balance,
+        defaultHarubee: data.defaultHarubee,
+        dailyBudgets: data.dailyBudgets
+      )
+    }
   }
-  
-  convenience init(_ data: SalaryBudget) {
-    self.init(
-      id: data.id,
-      startDate: data.startDate,
-      endDate: data.endDate,
-      fixedIncome: data.fixedIncome,
-      fixedExpenses: data.fixedExpenses,
-      balance: data.balance,
-      defaultHarubee: data.defaultHarubee,
-      dailyBudgets: data.dailyBudgets
-    )
+}
+
+
+
+extension SchemaV1 {
+  @Model
+  final class SalaryBudgetDTO {
+    @Attribute(.unique) var identifier: String
+    var startDate: Date
+    var endDate: Date
+    var fixedIncome: Int
+    @Relationship(deleteRule: .cascade) var fixedExpenses: [TransactionItemDTO]
+    var balance: Int
+    var defaultHarubee: Double
+    @Relationship(deleteRule: .cascade) var dailyBudgets: [DailyBudgetDTO]
+    
+    init(
+      id: String,
+      startDate: Date,
+      endDate: Date,
+      fixedIncome: Int,
+      fixedExpenses: [TransactionItem],
+      balance: Int,
+      defaultHarubee: Double,
+      dailyBudgets: [DailyBudget]
+    ) {
+      self.identifier = id
+      self.startDate = startDate
+      self.endDate = endDate
+      self.fixedIncome = fixedIncome
+      self.fixedExpenses = fixedExpenses.map {
+        TransactionItemDTO($0)
+      }
+      self.balance = balance
+      self.defaultHarubee = defaultHarubee
+      self.dailyBudgets = dailyBudgets.map {
+        DailyBudgetDTO($0)
+      }
+    }
+    
+    convenience init(_ data: SalaryBudget) {
+      self.init(
+        id: data.id,
+        startDate: data.startDate,
+        endDate: data.endDate,
+        fixedIncome: data.fixedIncome,
+        fixedExpenses: data.fixedExpenses,
+        balance: data.balance,
+        defaultHarubee: data.defaultHarubee,
+        dailyBudgets: data.dailyBudgets
+      )
+    }
   }
 }
 
@@ -63,7 +120,7 @@ extension SalaryBudgetDTO {
       fixedIncome: self.fixedIncome,
       fixedExpenses: self.fixedExpenses
         .map { $0.toEntity() }
-        .sorted { $0.date < $1.date },
+        .sorted { $0.day < $1.day },
       balance: self.balance,
       defaultHarubee: self.defaultHarubee,
       dailyBudgets: self.dailyBudgets

--- a/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
+++ b/Harubee/Sources/Data/DTOs/SalaryBudgetDTO.swift
@@ -11,6 +11,9 @@ import SwiftData
 
 typealias SalaryBudgetDTO = SchemaV2.SalaryBudgetDTO
 
+
+// MARK: - SchemaV2
+
 extension SchemaV2 {
   @Model
   final class SalaryBudgetDTO {
@@ -58,7 +61,7 @@ extension SchemaV2 {
   }
 }
 
-
+// MARK: - SchemaV1
 
 extension SchemaV1 {
   @Model
@@ -110,6 +113,9 @@ extension SchemaV1 {
     }
   }
 }
+
+
+// MARK: - toEntity()
 
 extension SalaryBudgetDTO {
   func toEntity() -> SalaryBudget {

--- a/Harubee/Sources/Data/DTOs/TransactionItemDTO.swift
+++ b/Harubee/Sources/Data/DTOs/TransactionItemDTO.swift
@@ -9,40 +9,87 @@
 import Foundation
 import SwiftData
 
-@Model
-final class TransactionItemDTO {
-  @Attribute(.unique) var identifier: String
-  var date: Date
-  var name: String
-  var price: Int
-  
-  init(
-    id: String,
-    date: Date,
-    name: String,
-    price: Int
-  ) {
-    self.identifier = id
-    self.date = date
-    self.name = name
-    self.price = price
-  }
-  
-  convenience init(_ data: TransactionItem) {
-    self.init(
-      id: data.id,
-      date: data.date,
-      name: data.name,
-      price: data.price
-    )
+
+// MARK: - SchemaV2
+
+typealias TransactionItemDTO = SchemaV2.TransactionItemDTO
+
+extension SchemaV2 {
+  @Model
+  final class TransactionItemDTO {
+    @Attribute(.unique) var identifier: String
+    var date: Date
+    var day: Int = 1
+    var name: String
+    var price: Int
+    
+    init(
+      id: String,
+      date: Date,
+      day: Int = 1,
+      name: String,
+      price: Int
+    ) {
+      self.identifier = id
+      self.date = date
+      self.day = day
+      self.name = name
+      self.price = price
+    }
+    
+    convenience init(_ data: TransactionItem) {
+      self.init(
+        id: data.id,
+        date: data.date,
+        day: data.day,
+        name: data.name,
+        price: data.price
+      )
+    }
   }
 }
 
+// MARK: - SchemaV1
+extension SchemaV1 {
+  
+  @Model
+  final class TransactionItemDTO {
+    @Attribute(.unique) var identifier: String
+    var date: Date
+    var name: String
+    var price: Int
+    
+    init(
+      id: String,
+      date: Date,
+      name: String,
+      price: Int
+    ) {
+      self.identifier = id
+      self.date = date
+      self.name = name
+      self.price = price
+    }
+    
+    convenience init(_ data: TransactionItem) {
+      self.init(
+        id: data.id,
+        date: data.date,
+        name: data.name,
+        price: data.price
+      )
+    }
+  }
+}
+
+
+// MARK: - toEntity()
 extension TransactionItemDTO {
   func toEntity() -> TransactionItem {
     return TransactionItem(
       id: self.identifier,
       date: self.date,
+      day: self.day,
       name: self.name,
       price: self.price
     )

--- a/Harubee/Sources/Domain/Models/TransactionItem.swift
+++ b/Harubee/Sources/Domain/Models/TransactionItem.swift
@@ -11,17 +11,20 @@ import Foundation
 struct TransactionItem: Identifiable, Equatable {
   let id: String
   var date: Date
+  var day: Int
   var name: String
   var price: Int
   
   init(
     id: String = UUID().uuidString,
     date: Date,
+    day: Int = 1,
     name: String,
     price: Int
   ) {
     self.id = id
     self.date = date
+    self.day = day
     self.name = name
     self.price = price
   }
@@ -29,6 +32,7 @@ struct TransactionItem: Identifiable, Equatable {
   static var `default`: TransactionItem {
     .init(
       date: .init(),
+      day: 1,
       name: "",
       price: 0
     )

--- a/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
+++ b/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
@@ -494,17 +494,33 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     // 2. UserDefaults에 설정하기
     try userDefaultsRepository.saveIncomeDay(day)
     
+    // 3. 새로운 수입일에 맞춰 월급 기간 구하기
     let (startDate, endDate) = Date.calculateStartAndEndDate(from: day, anchor: .now)
     
     // 4.  기존 salaryBudget 삭제하기
     try salaryBudgetRepository.deleteById(salaryBudget.id)
     
-    // 5. 새로운 SalaryBudget 생성
+    // 5. 새로운 수입일에 맞춰 고정 지출 날짜 새롭게 계산
+    let newFixedExpenses = salaryBudget.fixedExpenses.map {
+      let date = Date.convertDateBetweenStartAndEnd(
+        start: startDate,
+        end: endDate,
+        day: $0.day
+      )
+      return TransactionItem(
+        date: date,
+        day: $0.day,
+        name: $0.name,
+        price: $0.price
+      )
+    }
+    
+    // 6. 새로운 SalaryBudget 생성
     return try self.createSalaryBudget(
       startDate: startDate,
       endDate: endDate,
       fixedIncome: salaryBudget.fixedIncome,
-      fixedExpenses: salaryBudget.fixedExpenses
+      fixedExpenses: newFixedExpenses
     )
   }
   

--- a/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
+++ b/Harubee/Sources/Presentation/Onboarding/Views/Onboarding5View.swift
@@ -139,7 +139,7 @@ private struct FixedExpenseListView: View {
     .onChange(of: selectedItem) { _, _ in }
     .onChange(of: fixedExpenses) { _, _ in
       fixedExpenses.sort(by: {
-        $0.date.day < $1.date.day
+        $0.day < $1.day
       })
     }
   }
@@ -172,7 +172,7 @@ private struct FixedExpenseListView: View {
     for item: TransactionItem
   ) -> some View {
     HStack(spacing: 0) {
-      Text("매달 \(item.date.formattedDateToString(.day_kr))")
+      Text("매달 \(item.day)일")
         .font(.pretendardMedium_16)
         .foregroundStyle(Color.textBlack)
         .padding(.vertical, 6)
@@ -213,11 +213,13 @@ private struct FixedExpenseListView: View {
          $0.id == item.id
        }) {
       fixedExpenses[index].date = date
+      fixedExpenses[index].day = day
       fixedExpenses[index].name = name
       fixedExpenses[index].price = price.numberFormat ?? 0
     } else {
       fixedExpenses.append(.init(
         date: date,
+        day: day,
         name: name,
         price: price.numberFormat ?? 0
       ))

--- a/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
+++ b/Harubee/Sources/Presentation/Setting/Views/FixedExpenseView.swift
@@ -149,7 +149,7 @@ private struct FixedExpenseListView: View {
     for item: TransactionItem
   ) -> some View {
     HStack(spacing: 0) {
-      Text("매달 \(item.date.formattedDateToString(.day_kr))")
+      Text("매달 \(item.day)일")
         .font(.pretendardMedium_16)
         .foregroundStyle(Color.textBlack)
         .padding(.vertical, 6)
@@ -190,11 +190,13 @@ private struct FixedExpenseListView: View {
          $0.id == item.id
        }) {
       fixedExpenses[index].date = date
+      fixedExpenses[index].day = day
       fixedExpenses[index].name = name
       fixedExpenses[index].price = price.numberFormat ?? 0
     } else {
       fixedExpenses.append(.init(
         date: date,
+        day: day,
         name: name,
         price: price.numberFormat ?? 0
       ))

--- a/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
+++ b/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
@@ -92,9 +92,14 @@ extension TodayViewModel {
         let date = Date.convertDateBetweenStartAndEnd(
           start: newStartDate,
           end: newEndDate,
-          day: $0.date.day
+          day: $0.day
         )
-        return TransactionItem(date: date, name: $0.name, price: $0.price)
+        return TransactionItem(
+          date: date,
+          day: $0.day,
+          name: $0.name,
+          price: $0.price
+        )
       }
       
       // 4. 새로운 SalaryBudget 생성


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [x] Feature: 기능 추가
- [ ] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
SwiftData 모델인 TransactionItemDTO를 수정하기 위한 마이그레이션 작업을 진행했습니다.

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #200 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208982550113060

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

### 모델 변경 이유
변경 이유는 다음과 같습니다.
1. 현재 월급 기간을 11.15 ~ 12.14로 가정.
2. 고정 지출을 31일로 설정하여 추가.
3. 현재 TransactionItem에 저장되는 date 프로퍼티의 타입은 Date.
4. 따라서, 저장될 때 11.30 날짜로 저장이 되게 됨 
    (현재 월급 기간에서 11.31은 존재하지 않기 때문)
5. 다음 월급 기간(12.15~1.14)으로 넘어갈 때 12.30 날짜의 고정 지출로 저장되게 됨
    (다음 월급 기간에 대한 SalaryBudget은 이전 SalaryBudget을 기반으로 생성되게 되는데, 
    이전 SalaryBudget에서 고정 지출은 11.30 날짜로 저장되어있음.
    즉, 31일로 고정 지출이 추가되었다는 정보가 저장되어있지 않음)
6. 따라서, 일자(day)를 TransactionItem에 따로 저장해서 정확한 고정 지출 날짜를 구하고자 함

### 모델 변경 과정

1. VersionedSchema protocol을 사용하여 버전별로 사용되는 SwiftData 모델을 캡슐화
```swift

// Schema Version 정의

// 새롭게 변경할 모델들
enum SchemaV2: VersionedSchema {
  static var versionIdentifier: Schema.Version = .init(2, 0, 0)
  
  static var models: [any PersistentModel.Type] {
    [
      SalaryBudgetDTO.self, // SchemaV2.SalaryBudgetDTO
      DailyBudgetDTO.self, // SchemaV2.DailyBudgetDTO
      TransactionItemDTO.self // SchemaV2.TransactionItemDTO
    ]
  }
}

// 이전에 사용되던 모델들
enum SchemaV1: VersionedSchema {
  static var versionIdentifier: Schema.Version = .init(1, 0, 0)
  
  static var models: [any PersistentModel.Type] {
    [
      SalaryBudgetDTO.self, // SchemaV1.SalaryBudgetDTO
      DailyBudgetDTO.self, // SchemaV1.DailyBudgetDTO
      TransactionItemDTO.self // SchemaV1.TransactionItemDTO
    ]
  }
}
```

```swift
// Schema Version별 모델 정의

// 기존 코드에서 항상 최신 버전의 모델을 사용할 수 있도록 typealias 지정
typealias TransactionItemDTO = SchemaV2.TransactionItemDTO

extension SchemaV2 {
  @Model
  final class TransactionItemDTO {
    @Attribute(.unique) var identifier: String
    var date: Date
    var day: Int = 1 // 새롭게 추가된 프로퍼티
    var name: String
    var price: Int
    
    init(
      id: String,
      date: Date,
      day: Int = 1,
      name: String,
      price: Int
    ) {
      self.identifier = id
      self.date = date
      self.day = day
      self.name = name
      self.price = price
    }
  }
}

extension SchemaV1 {
  @Model
  final class TransactionItemDTO {
    @Attribute(.unique) var identifier: String
    var date: Date
    var name: String
    var price: Int
    
    init(
      id: String,
      date: Date,
      name: String,
      price: Int
    ) {
      self.identifier = id
      self.date = date
      self.name = name
      self.price = price
    }
  }
}

// SalaryBudgetDTO, DailyBudgetDTO도 동일하게 적용

```

2. SchemaMigrationPlan protocol을 이용하여 마이그레이션을 어떻게 수행할지 정의

```swift
enum MigrationPlan: SchemaMigrationPlan {
  static var schemas: [any VersionedSchema.Type] {
    [
      SchemaV1.self,
      SchemaV2.self
    ]
  }
  
  static var stages: [MigrationStage] {
    [migrateV1toV2]
  }
  
  static let migrateV1toV2 = MigrationStage.custom(
    fromVersion: SchemaV1.self,
    toVersion: SchemaV2.self,
    willMigrate: nil,
    didMigrate: { context in
      // 새롭게 마이그래이션된 TransactionItemDTO 모델들을 불러옴
      let transactionItems = try context.fetch(
        FetchDescriptor<TransactionItemDTO>()
      )
      
      // 각 TransactionItemDTO 모델에 알맞은 day 값으로 새롭게 업데이트
      for item in transactionItems {
        item.day = item.date.day
      }
      
      try context.save()
    }
  )
}
```

3. ModelContainer 생성 코드에 적용할 MigrationPlan 전달
```swift
lazy var modelContainer: ModelContainer = {
    ...
    
    do {
      let container = try ModelContainer(
        for: schema,
        migrationPlan: MigrationPlan.self, // 추가
        configurations: configuration
      )
      return container
    } catch {
      fatalError("Failed to create ModelContainer: \(error)")
    }
  }()
```

### 모델 변경 후 

31일 날짜에 대한 고정 지출을 추가하면 말일로 계산되어 월의 마지막 날에 적용됨
(2월의 경우 29일, 30일, 31일 모두 적용됨)

[영상 흐름]
1. 31일에 대한 고정 지출이 추가된 상태
2. 11.20 ~ 12.19 기간에서 11.30 날짜를 클릭하면 해당 고정 지출 내역이 보여짐
3. 12.20 ~ 1.19 기간에서 12.31 날짜를 클릭하면 해당 고정 지출 내역이 보여지고, 12.30 날짜를 클릭하면 보이지 않음.

https://github.com/user-attachments/assets/8224cd89-086d-4ebd-8c4b-5d40bcc38ae2



