### PR TITLE
[Hotfix] TodayView에서 사용되는 Timer 코드 수정

### DIFF
--- a/Harubee/Sources/Data/Repositories/Impls/UserDefaultsRepositoryImpl.swift
+++ b/Harubee/Sources/Data/Repositories/Impls/UserDefaultsRepositoryImpl.swift
@@ -24,7 +24,7 @@ final class UserDefaultsRepositoryImpl: UserDefaultsRepository {
     self.userDefaults = userDefaults
   }
   
-  func saveIncomeDay(_ day: Int) throws {
+  func saveIncomeDay(_ day: Int) {
     userDefaults.set(day, forKey: Keys.incomeDay)
   }
   
@@ -32,7 +32,7 @@ final class UserDefaultsRepositoryImpl: UserDefaultsRepository {
     userDefaults.object(forKey: Keys.incomeDay) as? Int
   }
   
-  func saveTodayHarubeeNotificationTime(_ time: Date) throws {
+  func saveTodayHarubeeNotificationTime(_ time: Date) {
     userDefaults.set(time, forKey: Keys.harubeeNotificationTime)
   }
 
@@ -40,7 +40,7 @@ final class UserDefaultsRepositoryImpl: UserDefaultsRepository {
     userDefaults.object(forKey: Keys.harubeeNotificationTime) as? Date
   }
 
-  func saveExpenseNotificationTime(_ time: Date) throws {
+  func saveExpenseNotificationTime(_ time: Date) {
     userDefaults.set(time, forKey: Keys.expenseNotificationTime)
   }
 
@@ -48,7 +48,7 @@ final class UserDefaultsRepositoryImpl: UserDefaultsRepository {
     userDefaults.object(forKey: Keys.expenseNotificationTime) as? Date
   }
   
-  func saveTodayHarubeeNotificationStatus(_ isEnabled: Bool) throws {
+  func saveTodayHarubeeNotificationStatus(_ isEnabled: Bool) {
     userDefaults.set(isEnabled, forKey: Keys.harubeeNotificationStatus)
   }
 
@@ -56,7 +56,7 @@ final class UserDefaultsRepositoryImpl: UserDefaultsRepository {
     return userDefaults.bool(forKey: Keys.harubeeNotificationStatus)
   }
 
-  func saveExpenseNotificationStatus(_ isEnabled: Bool) throws {
+  func saveExpenseNotificationStatus(_ isEnabled: Bool) {
     userDefaults.set(isEnabled, forKey: Keys.expenseNotificationStatus)
   }
 

--- a/Harubee/Sources/Domain/Repositories/UserDefaultsRepository.swift
+++ b/Harubee/Sources/Domain/Repositories/UserDefaultsRepository.swift
@@ -12,29 +12,27 @@ protocol UserDefaultsRepository {
   
   /// UserDefaults에 월급일을 저장합니다.
   /// - Parameter day: 저장할 월급일(1-31)
-  func saveIncomeDay(_ day: Int) throws
+  func saveIncomeDay(_ day: Int)
   
   /// UserDefaults에서 월급일을 읽어옵니다.
   /// - Returns: 저장된 월급일. 저장된 값이 없으면 nil
   func readIncomeDay() -> Int?
   
   /// UserDefaults에서 오늘의 하루비 알림시간을 저장합니다.
-  func saveTodayHarubeeNotificationTime(_ time: Date) throws
-  
+  func saveTodayHarubeeNotificationTime(_ time: Date)
   /// UserDefaults에서 오늘의 하루비 알림시간을 읽어옵니다.
   /// - Returns: 저장된 시간. 없으면 nil
   func readTodayHarubeeNotificationTime() -> Date?
   
   /// UserDefaults에서 실제 지출 입력 알림시간을 저장합니다.
-  func saveExpenseNotificationTime(_ time: Date) throws
-  
+  func saveExpenseNotificationTime(_ time: Date)
   /// UserDefaults에서 실제 지출 입력 알림시간을 읽어옵니다.
   /// - Returns: 저장된 시간. 없으면 nil
   func readExpenseNotificationTime() -> Date?
   
   /// UserDefaults에서 오늘의 하루비 알림 활성 상태를 저장합니다.
   /// - Parameter isEnabled: 활성화 상태
-  func saveTodayHarubeeNotificationStatus(_ isEnabled: Bool) throws
+  func saveTodayHarubeeNotificationStatus(_ isEnabled: Bool)
   
   /// UserDefaults에서 오늘의 하루비 알림 활성 상태를 읽어옵니다.
   /// - Returns: 저장된 활성화 상태. 없으면 기본값 true
@@ -42,8 +40,7 @@ protocol UserDefaultsRepository {
   
   /// UserDefaults에서 실제 지출 입력 알림 활성 상태를 저장합니다.
   /// - Parameter isEnabled: 활성화 상태
-  func saveExpenseNotificationStatus(_ isEnabled: Bool) throws
-  
+  func saveExpenseNotificationStatus(_ isEnabled: Bool)
   /// UserDefaults에서 실제 지출 입력 알림 활성 상태를 읽어옵니다.
   /// - Returns: 저장된 활성화 상태. 없으면 기본값 true
   func readExpenseNotificationStatus() -> Bool?

--- a/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
+++ b/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
@@ -481,7 +481,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   }
   
   
-  func setIncomeDay(
+  func updateIncomeDay(
     day: Int,
     salaryBudget: SalaryBudget
   ) throws -> SalaryBudget {
@@ -524,16 +524,12 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     )
   }
   
+  func setIncomeDay(day: Int) throws {
+    try userDefaultsRepository.saveIncomeDay(day)
+  }
   
-  func getIncomeDay() throws -> Int {
-    
-    // 1. 월급일을 가져오고 저장된 월급일이 없으면 기본값 1로 설정하기
-    guard let incomeDay = userDefaultsRepository.readIncomeDay() else {
-      try userDefaultsRepository.saveIncomeDay(1)
-      return 1
-    }
-    
-    return incomeDay
+  func getIncomeDay() throws -> Int? {
+    return userDefaultsRepository.readIncomeDay()
   }
   
   func setTodayHarubeeNotificationTime(time: Date) {

--- a/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
+++ b/Harubee/Sources/Domain/UseCases/Impls/BudgetUseCaseImpl.swift
@@ -492,7 +492,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     }
     
     // 2. UserDefaults에 설정하기
-    try userDefaultsRepository.saveIncomeDay(day)
+    userDefaultsRepository.saveIncomeDay(day)
     
     // 3. 새로운 수입일에 맞춰 월급 기간 구하기
     let (startDate, endDate) = Date.calculateStartAndEndDate(from: day, anchor: .now)
@@ -524,16 +524,16 @@ final class BudgetUseCaseImpl: BudgetUseCase {
     )
   }
   
-  func setIncomeDay(day: Int) throws {
-    try userDefaultsRepository.saveIncomeDay(day)
+  func setIncomeDay(day: Int) {
+    userDefaultsRepository.saveIncomeDay(day)
   }
   
-  func getIncomeDay() throws -> Int? {
+  func getIncomeDay() -> Int? {
     return userDefaultsRepository.readIncomeDay()
   }
   
   func setTodayHarubeeNotificationTime(time: Date) {
-    try? userDefaultsRepository.saveTodayHarubeeNotificationTime(time)
+    userDefaultsRepository.saveTodayHarubeeNotificationTime(time)
   }
 
   func getTodayHarubeeNotificationTime() -> Date? {
@@ -549,7 +549,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
       dateComponents.timeZone = TimeZone.current
       
       let defaultDate = calendar.date(from: dateComponents)
-      try? userDefaultsRepository.saveTodayHarubeeNotificationTime(defaultDate!)
+      userDefaultsRepository.saveTodayHarubeeNotificationTime(defaultDate!)
       
       return defaultDate
     }
@@ -558,7 +558,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   }
 
   func setExpenseNotificationTime(time: Date) {
-    try? userDefaultsRepository.saveExpenseNotificationTime(time)
+    userDefaultsRepository.saveExpenseNotificationTime(time)
   }
 
   func getExpenseNotificationTime() -> Date? {
@@ -574,7 +574,7 @@ final class BudgetUseCaseImpl: BudgetUseCase {
       dateComponents.timeZone = TimeZone.current
       
       let defaultDate = calendar.date(from: dateComponents)
-      try? userDefaultsRepository.saveExpenseNotificationTime(defaultDate!)
+      userDefaultsRepository.saveExpenseNotificationTime(defaultDate!)
       
       return defaultDate
     }
@@ -583,26 +583,26 @@ final class BudgetUseCaseImpl: BudgetUseCase {
   }
   
   func setTodayHarubeeNotificationStatus(_ isEnabled: Bool) {
-    try? userDefaultsRepository.saveTodayHarubeeNotificationStatus(isEnabled)
+    userDefaultsRepository.saveTodayHarubeeNotificationStatus(isEnabled)
   }
 
-  func getTodayHarubeeNotificationStatus() throws -> Bool? {
+  func getTodayHarubeeNotificationStatus() -> Bool? {
     guard let status = userDefaultsRepository.readTodayHarubeeNotificationStatus()
     else {
-      try? userDefaultsRepository.saveTodayHarubeeNotificationStatus(false)
+      userDefaultsRepository.saveTodayHarubeeNotificationStatus(false)
       return false
     }
     return status
   }
 
   func setExpenseNotificationStatus(_ isEnabled: Bool) {
-    try? userDefaultsRepository.saveExpenseNotificationStatus(isEnabled)
+    userDefaultsRepository.saveExpenseNotificationStatus(isEnabled)
   }
 
-  func getExpenseNotificationStatus() throws -> Bool? {
+  func getExpenseNotificationStatus() -> Bool? {
     guard let status = userDefaultsRepository.readExpenseNotificationStatus()
     else {
-      try? userDefaultsRepository.saveTodayHarubeeNotificationStatus(false)
+      userDefaultsRepository.saveTodayHarubeeNotificationStatus(false)
       return false
     }
     return status

--- a/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
+++ b/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
@@ -180,19 +180,22 @@ protocol BudgetUseCase {
   ) throws -> DailyBudget
   
   
-  /// 고정 수입일을 설정합니다.
+  /// 고정 수입일을 수정합니다.
   /// - Parameter day: 1-31 사이의 일자
   /// - Throws:
   ///   - `DomainError.dateOutOfRange`: 유효하지 않은 일자인 경우
-  func setIncomeDay(
+  func updateIncomeDay(
     day: Int,
     salaryBudget: SalaryBudget
   ) throws -> SalaryBudget
   
+  /// 고정 수입일을 저장합니다.
+  /// - Parameter day: 1-31 사이의 일자
+  func setIncomeDay(day: Int) throws
   
   /// 저장된 고정 수입일을 조회합니다.
   /// - Returns: 1-31 사이의 고정 수입일
-  func getIncomeDay() throws -> Int
+  func getIncomeDay() throws -> Int?
   
   /// 오늘의 하루비 알림을 보여주는 시간을 설정합니다
   func setTodayHarubeeNotificationTime(time: Date)

--- a/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
+++ b/Harubee/Sources/Domain/UseCases/Interfaces/BudgetUseCase.swift
@@ -191,39 +191,39 @@ protocol BudgetUseCase {
   
   /// 고정 수입일을 저장합니다.
   /// - Parameter day: 1-31 사이의 일자
-  func setIncomeDay(day: Int) throws
+  func setIncomeDay(day: Int)
   
   /// 저장된 고정 수입일을 조회합니다.
   /// - Returns: 1-31 사이의 고정 수입일
-  func getIncomeDay() throws -> Int?
+  func getIncomeDay() -> Int?
   
   /// 오늘의 하루비 알림을 보여주는 시간을 설정합니다
   func setTodayHarubeeNotificationTime(time: Date)
   
   /// 저장된 오늘의 하루비 알림 시간을 조회합니다.
   /// - Returns: 0~24시 0~60분
-  func getTodayHarubeeNotificationTime() throws -> Date?
+  func getTodayHarubeeNotificationTime() -> Date?
   
   /// 실제 지출을 입력하는 알림을 보여주는 시간을 설정합니다
   func setExpenseNotificationTime(time: Date)
   
   /// 저장된 실제 지출을 입력하는 알림 시간을 조회합니다.
   /// - Returns: 0~24시 0~60분
-  func getExpenseNotificationTime() throws -> Date?
+  func getExpenseNotificationTime() -> Date?
   
   /// 오늘의 하루비 알림 활성화 상태를 설정합니다
   func setTodayHarubeeNotificationStatus(_ isEnabled: Bool)
   
   /// 오늘의 하루비 알림 활성화 상태를 조회합니다
   /// - Returns: 알림 활성화 상태
-  func getTodayHarubeeNotificationStatus() throws -> Bool?
+  func getTodayHarubeeNotificationStatus() -> Bool?
   
   /// 실제 지출 입력 알림 활성화 상태를 설정합니다
   func setExpenseNotificationStatus(_ isEnabled: Bool)
   
   /// 실제 지출 입력 알림 활성화 상태를 조회합니다
   /// - Returns: 알림 활성화 상태
-  func getExpenseNotificationStatus() throws -> Bool?
+  func getExpenseNotificationStatus() -> Bool?
   
   /// 오늘날짜 이전에 해당하는 DailyBudget에 하루비가 저장되지 않았는지 확인 후 값을 넣어줍니다.
   /// - Parameter salaryBudget: 이번 기간의 SalaryBudget

--- a/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -71,6 +71,8 @@ final class OnboardingViewModel {
         fixedIncome: self.state.incomeAmount ?? 0,
         fixedExpenses: self.state.fixedExpenses
       )
+      
+      try? budgetUseCase.setIncomeDay(day: self.state.incomeStartDate.day)
     }
     
     self.state.averageHarubee = self.calculateAverageHarubee()

--- a/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Harubee/Sources/Presentation/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -72,7 +72,7 @@ final class OnboardingViewModel {
         fixedExpenses: self.state.fixedExpenses
       )
       
-      try? budgetUseCase.setIncomeDay(day: self.state.incomeStartDate.day)
+      budgetUseCase.setIncomeDay(day: self.state.incomeStartDate.day)
     }
     
     self.state.averageHarubee = self.calculateAverageHarubee()

--- a/Harubee/Sources/Presentation/Setting/ViewModels/SettingViewModel.swift
+++ b/Harubee/Sources/Presentation/Setting/ViewModels/SettingViewModel.swift
@@ -123,10 +123,10 @@ final class SettingViewModel {
   
   private func fetchNotificationData() {
 
-    let harubeeNotificationTime = try? budgetUseCase.getTodayHarubeeNotificationTime()
-    let expenseNotificationTime = try? budgetUseCase.getExpenseNotificationTime()
-    let harubeeNotificationStatus = try? budgetUseCase.getTodayHarubeeNotificationStatus()
-    let expenseNotificationStatus = try? budgetUseCase.getExpenseNotificationStatus()
+    let harubeeNotificationTime = budgetUseCase.getTodayHarubeeNotificationTime()
+    let expenseNotificationTime = budgetUseCase.getExpenseNotificationTime()
+    let harubeeNotificationStatus = budgetUseCase.getTodayHarubeeNotificationStatus()
+    let expenseNotificationStatus = budgetUseCase.getExpenseNotificationStatus()
     
     self.harubeeNotificationTime = harubeeNotificationTime ?? Date()
     self.expenseNotificationTime = expenseNotificationTime ?? Date()

--- a/Harubee/Sources/Presentation/Setting/ViewModels/SettingViewModel.swift
+++ b/Harubee/Sources/Presentation/Setting/ViewModels/SettingViewModel.swift
@@ -136,7 +136,7 @@ final class SettingViewModel {
   
   private func updateFixedIncomeDay(_ incomeDay: Int) {
     do {
-      let newSalaryBudget = try budgetUseCase.setIncomeDay(
+      let newSalaryBudget = try budgetUseCase.updateIncomeDay(
         day: incomeDay,
         salaryBudget: self.state.salaryBudget
       )

--- a/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
+++ b/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
@@ -76,13 +76,13 @@ extension TodayViewModel {
       ) else { return }
       
       // 3. 새로운 시작일과 종료일 계산
-      var incomeDay = try? budgetUseCase.getIncomeDay()
+      var incomeDay = budgetUseCase.getIncomeDay()
       
       // 온보딩이 끝날 때 수입일을 저장해야하는걸 까먹고 못했습니다..
       // 그래서 UserDefaults에 nil로 저장이 돼있을 수 있기 때문에 다음과 같은 코드를 추가했습니다.
       // 현재는 추가된 상태이고, 따라서 2월쯤에는 아래 코드는 지워도 될 거 같습니다.
       if incomeDay == nil {
-        try? budgetUseCase.setIncomeDay(day: recentSalaryBudget.startDate.day)
+        budgetUseCase.setIncomeDay(day: recentSalaryBudget.startDate.day)
         incomeDay = recentSalaryBudget.startDate.day
       }
       

--- a/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
+++ b/Harubee/Sources/Presentation/Today/ViewModels/TodayViewModel.swift
@@ -76,18 +76,22 @@ extension TodayViewModel {
       ) else { return }
       
       // 3. 새로운 시작일과 종료일 계산
-      // TODO: 수정 필요
-      let (newStartDate, newEndDate) = calculateNewSalaryBudgetDates(
-        referenceStartDay: Calendar.current.component(
-          .day,
-          from: recentSalaryBudget.startDate
-        ),
-        today: Calendar.current.component(
-          .day,
-          from: state.todayDate
-        )
+      var incomeDay = try? budgetUseCase.getIncomeDay()
+      
+      // 온보딩이 끝날 때 수입일을 저장해야하는걸 까먹고 못했습니다..
+      // 그래서 UserDefaults에 nil로 저장이 돼있을 수 있기 때문에 다음과 같은 코드를 추가했습니다.
+      // 현재는 추가된 상태이고, 따라서 2월쯤에는 아래 코드는 지워도 될 거 같습니다.
+      if incomeDay == nil {
+        try? budgetUseCase.setIncomeDay(day: recentSalaryBudget.startDate.day)
+        incomeDay = recentSalaryBudget.startDate.day
+      }
+      
+      let (newStartDate, newEndDate) = Date.calculateStartAndEndDate(
+        from: incomeDay!,
+        anchor: .now
       )
       
+      // 4. 새로운 수입일에 맞춰 고정 지출 날짜 새롭게 계산
       let newFixedExpenses = recentSalaryBudget.fixedExpenses.map {
         let date = Date.convertDateBetweenStartAndEnd(
           start: newStartDate,
@@ -102,7 +106,7 @@ extension TodayViewModel {
         )
       }
       
-      // 4. 새로운 SalaryBudget 생성
+      // 5. 새로운 SalaryBudget 생성
       if let newSalaryBudget = try? budgetUseCase.createSalaryBudget(
         startDate: newStartDate,
         endDate: newEndDate,
@@ -113,63 +117,6 @@ extension TodayViewModel {
       }
     } catch {
       print("other error: \(error)")
-    }
-  }
-  
-  private func calculateNewSalaryBudgetDates(
-    referenceStartDay: Int, today: Int
-  ) -> (Date, Date) {
-    let calendar = Calendar.current
-    
-    if today < referenceStartDay {
-      let previousMonthDate = calendar.date(
-        byAdding: .month,
-        value: -1,
-        to: state.todayDate
-      )!
-      
-      let newStartDate = calendar.date(
-        from: DateComponents(
-          year: calendar.component(.year, from: previousMonthDate),
-          month: calendar.component(.month, from: previousMonthDate),
-          day: referenceStartDay
-        )
-      )!
-      
-      let newEndDate = calendar.date(
-        from: DateComponents(
-          year: calendar.component(.year, from: state.todayDate),
-          month: calendar.component(.month, from: state.todayDate),
-          day: referenceStartDay - 1
-        )
-      )!
-      
-      return (newStartDate, newEndDate)
-      
-    } else {
-      let nextMonthDate = calendar.date(
-        byAdding: .month,
-        value: 1,
-        to: state.todayDate
-      )!
-      
-      let newStartDate = calendar.date(
-        from: DateComponents(
-          year: calendar.component(.year, from: state.todayDate),
-          month: calendar.component(.month, from: state.todayDate),
-          day: referenceStartDay
-        )
-      )!
-      
-      let newEndDate = calendar.date(
-        from: DateComponents(
-          year: calendar.component(.year, from: nextMonthDate),
-          month: calendar.component(.month, from: nextMonthDate),
-          day: referenceStartDay - 1
-        )
-      )!
-      
-      return (newStartDate, newEndDate)
     }
   }
   

--- a/Harubee/Sources/Presentation/Today/Views/TodayView.swift
+++ b/Harubee/Sources/Presentation/Today/Views/TodayView.swift
@@ -214,7 +214,7 @@ private struct HarubeeHexagon: View {
   
   private let fillPercentage: Double
   private let isTodayExpenseEntered: Bool
-  private let waveTimer = Timer.publish(
+  @State private var waveTimer = Timer.publish(
     every: 0.03, on: .main, in: .common
   ).autoconnect()
 
@@ -300,6 +300,14 @@ private struct HarubeeHexagon: View {
         }
         
       }
+    }
+    .onAppear {
+      self.waveTimer = Timer.publish(
+        every: 0.03, on: .main, in: .common
+      ).autoconnect()
+    }
+    .onDisappear {
+      self.waveTimer.upstream.connect().cancel()
     }
     .onReceive(waveTimer) { _ in
 


### PR DESCRIPTION
<!-- PR 제목 컨벤션: [이슈 라벨] 작업한 내용 요약 -->

## 💡 PR 유형
<!-- 해당하는 유형에 "x"를 입력하세요. -->
- [ ] Feature: 기능 추가
- [x] Hotfix: 작은 버그 수정
- [ ] Bugfix: 큰 버그 수정
- [ ] Refactor: 코드 개선
- [ ] Chore: 환경 설정

## ✏️ 변경 사항
<!-- 이 PR에서 작업한 내용을 간단히 요약해주세요. -->
TodayView에서 사용되는 Timer 코드를 TodayView가 onAppear 시 타이머 활성화, onDisappear 시 타이머 비활성화되도록 수정했습니다.
위 수정사항을 통해 아래 문제를 해결했습니다.
- iOS 18.0 버전에서 나타났던 고정지출 수정 화면에서 DayPicker wheel이 제대로 동작하지 않는 문제
  (wheel을 움직이려해도 원위치로 돌아오던 문제)
- TodayView에서 내비게이션을 통해 다른 화면으로 이동해도 Timer 동작으로 인해 메인 쓰레드에 계속해서 부하가 가해지는 문제

## 🚨 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. 여러 개인 경우 쉼표로 구분하세요. -->
- #202 

## 📝 Pull Request Task ID
<!-- 아사나 작업 ID를 입력해주세요. 작업을 생성하며 같이 생성된 이슈 본문에 있습니다. -->
Pull Request Task ID: 1208995592439586

## 🧪 테스트
<!-- 이 PR에서 테스트한 내용을 설명해주세요. -->
- [x] 목표한 구현 정상 동작 확인

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "" width ="250">|

## ✅ 체크리스트
<!-- 꼭 모두 체크하고 PR을 생성해주세요. -->
- [x] 코드/커밋이 정해진 컨벤션을 잘 따르고 있나요?
- [x] PR의 Assignees와 Reviewers를 설정했나요?
- [x] 불필요한 코드가 없고, 정상적으로 동작하는지 확인했나요?
- [x] 관련 이슈 번호를 작성했나요?
- [x] Pull Request Task ID를 작성했나요?

## 🔥 추가 설명
<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 여기에 적어주세요. -->
<!-- 코드 리뷰를 받고 싶은 코드나, 설명하고 싶은 코드가 있다면 적어주세요. -->

### 문제 상황

iOS 18.0 버전에서 다음과 같이 picker의 wheel이 제대로 동작하지 않는 문제가 발생했었습니다.

<img src = "https://github.com/user-attachments/assets/c2ee6b37-e4e9-4706-8912-3207f8fb28b8" width ="250">

그런데, 이와 동일한 뷰가 사용되는 온보딩 화면에서는 해당 문제가 발생하지 않았습니다.

<img src = "https://github.com/user-attachments/assets/cd07f8f4-2197-495d-82e6-04bc21756019" width ="250">

그래서 Xcode의 성능 측정 도구인 Instruments를 이용해서 문제의 원인을 찾아보고자 했습니다.

각 화면에 대해 분석된 결과는 다음과 같았습니다.

|||
|:--:|:--:|
|온보딩 화면|<img src = "https://github.com/user-attachments/assets/8cbd0c02-24e8-4c93-8f3d-aa4cf00182c6" width ="350">|
|설정 화면|<img src = "https://github.com/user-attachments/assets/b98533aa-8d19-4ab2-8011-109df89fc6fe" width ="350">|

여기서 타임라인을 드래그한 영역에서 View Body 부분을 주목해볼 필요가 있는데, View Body는 얼마나 많은 View가 만들어지고 만들어지는데 어느정도 시간이 걸리는지 보여줍니다.

온보딩 화면에서와 달리, 설정 화면에서는 계속해서 뷰가 업데이트 되고 있는 것을 확인할 수 있었습니다.
그리고 해당 영역을 확대해서 확인해본 결과 업데이트가 되고 있는 뷰는 `TodayView`에서 사용되는 `HarubeeHexagon`이었음을 알 수 있었습니다.
![000](https://github.com/user-attachments/assets/7a758de1-e437-43ca-871f-edbbf1d80e1c)

현재 `HarubeeHexagon`에서 물결 애니메이션을 사용하고 있는데, 이를 위해 사용되는 Timer 객체가 원인이 되는지를 확인해보기 위해 기존 주기 0.03초에서 100초로 설정한 후 다시 실행해본 결과 정상 동작하는 것을 확인했습니다.

결론은 `TodayView`에서 설정 화면으로 이동할 때 Timer의 동작이 종료되지 않고 계속 활성화된 상태에서 뷰가 0.03초마다 업데이트 되고 있었고, 그로인해 설정 화면에서도 뷰가 업데이트 되어 picker의 값이 변경되기 전에 값이 원상태로 돌아오는 문제가 발생했었습니다.

또 다른 문제로는, 설정 화면에서 아무런 동작을 하지 않아도 타이머는 계속 동작하고 있기 때문에 메인 쓰레드에 계속해서 부하가 가해지게 되고 CPU 사용량이 높은 상태로 유지되는 성능 문제 또한 발견할 수 있었습니다.

![1121212](https://github.com/user-attachments/assets/b531a340-1883-449d-b118-07d0da5b7934)

이러한 문제들을 해결하고자, TodayView가 보일 때만 Timer를 활성화 시키고 보이지 않을 때는 Timer를 비활성화 시키는 작업을 진행했습니다.

### 문제 해결

```swift
// 기존 코드
private struct HarubeeHexagon: View {
    private let waveTimer = Timer.publish(
        every: 0.03, on: .main, in: .common
    ).autoconnect()
    
    ...
    
    var body: some View { ... }
      .onReceive(waveTimer) { ... }
}

// 변경 코드
private struct HarubeeHexagon: View {
    @State private var waveTimer = Timer.publish(
        every: 0.03, on: .main, in: .common
    ).autoconnect()
    
    ...
    
    var body: some View { ... }
      .onReceive(waveTimer) { ... }
      .onAppear {
          self.waveTimer = Timer.publish(
              every: 0.03, on: .main, in: .common
          ).autoconnect()
       }
       .onDisappear {
           self.waveTimer.upstream.connect().cancel()
       }
}
```

### 결과

기존 wheel 동작도 정상적으로 이루어지게 되고, CPU 성능 문제 또한 개선된 것을 확인할 수 있습니다.


https://github.com/user-attachments/assets/5c48b955-9a2c-4af5-9bb5-f402a2c2803e

